### PR TITLE
データベースの接続設定を修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -60,7 +60,6 @@ development:
 test:
   <<: *default
   database: haby_test
-  host: localhost
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## 概要
Docker環境でRailsがPostgreSQLに接続できない問題を修正しました。

## 目的
- database.ymlとdocker-compose.ymlの設定不整合により接続エラーが発生していたため、その解消。
- Docker上でアプリが安定して起動できるようにする。

## 作業内容
- config/database.ymlの項目修正
- docker-compose.ymlの内容を確認し、Rails側の設定と統一

## 確認事項
- [x] `docker compose up` が正常に完走する
- [x] Rails が http://localhost:3000で起動する

## 関連 Issue
なし

## 備考
特になし
