### PR TITLE
ヘッダーの作成

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -260,7 +260,7 @@
   margin: 4px 0;
 }
 
-/* エラーメッセージのスタイル（devise/shared/error_messages 用） */
+/* エラーメッセージのスタイル（devise/shared/error_messages） */
 .error_explanation {
   margin-bottom: 16px;
   padding: 12px 14px;
@@ -284,5 +284,96 @@
 .error_explanation li {
   font-size: 13px;
   color: #b91c1c;
+}
+
+/* ===============================
+   Header
+   =============================== */
+
+.app-header {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 12px;
+}
+
+.app-header__inner {
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0 30px;
+
+  display: flex;
+  align-items: center;
+}
+
+/* 左右に同じだけの「余白エリア」を持たせるイメージ */
+.app-header__left,
+.app-header__auth {
+  flex: 1;  /* 左右が同じ比率で広がる → ロゴがど真ん中になる */
+}
+
+/* 中央ロゴ */
+.app-header__center {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.app-header__logo-link {
+  display: inline-block;
+}
+
+.app-header__logo {
+  height: 50px;
+  width: auto;
+  display: block;
+}
+
+/* 右上のログイン/新規登録エリア */
+.app-header__auth {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end; /* 右寄せ */
+  gap: 12px;
+}
+
+.app-header__auth-link {
+  font-size: 13px;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid #117BBF;
+  color: #117BBF;
+  background-color: #ffffff;
+  white-space: nowrap; /* 「新規登録」を1行で表示する */
+}
+
+.app-header__auth-link--primary {
+  background-color: #117BBF;
+  color: #ffffff;
+}
+
+.app-header__auth-link:hover {
+  opacity: 0.9;
+}
+
+.app-header__user-name {
+  font-size: 13px;
+  color: #666666;
+}
+
+/* main コンテンツ側の余白（ヘッダー分） */
+.app-main {
+  max-width: 960px;
+  margin: 24px auto;
+  padding: 0 20px 40px;
+}
+
+/* 背景のオレンジ波形　*/
+.wave-background {
+  width: 100%;
+  background: 
+    radial-gradient(ellipse at bottom left, rgba(255, 198, 170, 0.55), transparent 70%),
+    radial-gradient(ellipse at bottom right, rgba(255, 198, 170, 0.45), transparent 75%);
 }
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,4 @@
+
 <div class="top-wrapper">
 
   <section class="hero">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,16 +26,11 @@
       <p class="alert"><%= alert %></p>
     <% end %>
 
-  <header>
-    <% if user_signed_in? %>
-      <span><%= current_user.name.presence || current_user.email %></span>
-      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "logout-button" %>
-    <% else %>
-      <%= link_to "新規登録", new_user_registration_path %>
-      <%= link_to "ログイン", new_user_session_path %>
-    <% end %>
-  </header>
-
-    <%= yield %>
+  <%= render "shared/header" %>
+  <div class="wave-background">
+    <main class="app-main">
+      <%= yield %>
+    </main>
+  </div>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,28 @@
+<header class="app-header">
+  <div class="app-header__inner">
+
+    <!-- 左側エリア -->
+    <div class="app-header__left"></div>
+
+    <!-- 中央ロゴ -->
+    <div class="app-header__center">
+      <%= link_to root_path, class: "app-header__logo-link" do %>
+        <%= image_tag "haby-logo.png", alt: "haby logo", class: "app-header__logo" %>
+      <% end %>
+    </div>
+
+    <!-- 右側エリア（ログイン/ログアウト） -->
+    <div class="app-header__auth">
+      <% if user_signed_in? %>
+        <span class="app-header__user-name">
+          <%= current_user.name.presence || "ログイン中" %>
+        </span>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "app-header__logout-button" %>
+      <% else %>
+        <%= link_to "ログイン", new_user_session_path, class: "app-header__auth-link" %>
+        <%= link_to "新規登録", new_user_registration_path, class: "app-header__auth-link app-header__auth-link--primary" %>
+      <% end %>
+    </div>
+
+  </div>
+</header>


### PR DESCRIPTION
## 概要
- アプリ全体で共通利用するヘッダーを作成する。
- オレンジ色のグラデーション背景をCSSで実装

## 目的
- ユーザーが見やすく、迷わず操作できるようにするため。

## 作業内容
- shared/_header.html.erb を作成
- ロゴを表示
- PC用デザイン・スタイル調整
- オレンジ色の背景用クラスを追加

## 確認事項
- [ ] 全ページに共通ヘッダーが表示される  
- [ ] ロゴ・タイトル・説明テキストが崩れずに表示されること
- [ ] オレンジの背景がスマホ幅で自然な形に表示されること
- [ ] 既存ページの表示に影響が出ていないこと

## 関連issue
- close #15 

## 備考
- 文言・色味・余白などは今後もデザイン調整予定です