### PR TITLE
ハンバーガーメニューの実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -327,19 +327,35 @@
    Header
    =============================== */
 
+/* ===============================
+   Header
+   =============================== */
+
 .app-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   background-color: #ffffff;
-  border-bottom: 1px solid #e5e5e5;
-  padding: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
 }
 
 .app-header__inner {
-  width: 100%;
-  max-width: 100%;
-  margin: 0;
-  padding: 0 30px;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 12px 16px;
   display: flex;
   align-items: center;
+}
+
+/* 左はダミー幅（ロゴ中央寄せ用） */
+.app-header__left {
+  width: 40px;
+}
+
+/* 中央ロゴ */
+.app-header__center {
+  flex: 1;
+  display: flex;
   justify-content: center;
 }
 
@@ -353,10 +369,106 @@
   display: block;
 }
 
-.app-header__user-name {
-  font-size: 13px;
-  color: #666666;
+/* 右側：ハンバーガー */
+.app-header__right {
+  display: flex;
+  align-items: center;
 }
+
+/* ハンバーガーボタン */
+.app-header__menu-button {
+  background: transparent;
+  border: none;
+  padding: 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app-header__menu-line {
+  width: 44px;
+  height: 4px;
+  border-radius: 999px;
+  background-color: #117BBF;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+/* 開いたときにXマーク化 */
+.app-header.is-menu-open .app-header__menu-line:nth-child(1) {
+  transform: translateY(12px) rotate(45deg);
+}
+
+.app-header.is-menu-open .app-header__menu-line:nth-child(2) {
+  opacity: 0;
+}
+
+.app-header.is-menu-open .app-header__menu-line:nth-child(3) {
+  transform: translateY(-12px) rotate(-45deg);
+}
+
+/* ===============================
+   右からスライドするメニュー
+   =============================== */
+
+/* ドロワー本体 */
+.app-header__nav {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+
+  width: 70%;          /* メニューの横幅 */
+  max-width: 320px;    /* PCで広くなりすぎないように */
+  background-color: #fbfbfb;
+
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.12);
+
+  z-index: 55;         /* ヘッダー（50） & bottom-nav（40）より上 */
+
+  /* 初期状態：画面外（右）に隠す */
+  transform: translateX(100%);
+  transition: transform 0.3s ease-out;
+}
+
+/* 開いているとき：右からスッと出てくる */
+.app-header.is-menu-open .app-header__nav {
+  transform: translateX(0);
+}
+
+/* メニューの中身 */
+.app-header__nav-list {
+  margin: 64px 16px 16px;   /* 上の余白でロゴ＆×印から少し下げる */
+  padding: 12px 8px 16px;
+  list-style: none;
+}
+
+.app-header__nav-list li + li {
+  margin-top: 12px;
+}
+
+.app-header__nav-link {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #333333;
+  font-size: 15px;
+}
+
+.app-header__nav-link:hover {
+  background-color: #e5e7eb;
+}
+
+
+/* 右端に固定配置されるハンバーガー */
+.app-header__menu-button--fixed {
+  position: absolute;
+  top: 12px;   /* ヘッダー内での上下位置 */
+  right: 12px; /* 画面右端からの距離 */
+  z-index: 60;
+}
+
 
 /* ===============================
    Footer

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./hamburger_menu";

--- a/app/javascript/hamburger_menu.js
+++ b/app/javascript/hamburger_menu.js
@@ -1,0 +1,68 @@
+// app/javascript/hamburger_menu.js
+
+// 直前のページで付けたイベントを外すためのクリーンアップ用変数
+let cleanupHamburger = null;
+
+const initHamburgerMenu = () => {
+  // まず前のページで付けたイベントを解除
+  if (cleanupHamburger) {
+    cleanupHamburger();
+    cleanupHamburger = null;
+  }
+
+  const header = document.querySelector(".app-header");
+  const button = document.getElementById("js-hamburger-button");
+  const nav = document.getElementById("global-nav");
+
+  // このページにヘッダー or メニューがないなら何もしない
+  if (!header || !button || !nav) return;
+
+  const toggleMenu = () => {
+    const isOpen = header.classList.toggle("is-menu-open");
+    button.setAttribute("aria-expanded", String(isOpen));
+  };
+
+  const onButtonClick = (event) => {
+    event.stopPropagation();
+    toggleMenu();
+  };
+
+  const onDocumentClick = (event) => {
+    if (!header.classList.contains("is-menu-open")) return;
+
+    // ボタン or メニューの中をクリックしているなら閉じない
+    if (
+      button.contains(event.target) ||
+      nav.contains(event.target)
+    ) {
+      return;
+    }
+
+    header.classList.remove("is-menu-open");
+    button.setAttribute("aria-expanded", "false");
+  };
+
+  const onNavClick = () => {
+    if (!header.classList.contains("is-menu-open")) return;
+    header.classList.remove("is-menu-open");
+    button.setAttribute("aria-expanded", "false");
+  };
+
+  // イベントを登録
+  button.addEventListener("click", onButtonClick);
+  document.addEventListener("click", onDocumentClick);
+  nav.addEventListener("click", onNavClick);
+
+  // 次のページ遷移時に外せるように退避
+  cleanupHamburger = () => {
+    button.removeEventListener("click", onButtonClick);
+    document.removeEventListener("click", onDocumentClick);
+    nav.removeEventListener("click", onNavClick);
+  };
+};
+
+// Turbo でページが表示されるたびに初期化
+document.addEventListener("turbo:load", initHamburgerMenu);
+
+// （念のため通常リロード用も付けておく）
+document.addEventListener("DOMContentLoaded", initHamburgerMenu);

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,36 @@
 <header class="app-header">
   <div class="app-header__inner">
+    <!-- 左側（ダミー） -->
+    <div class="app-header__left"></div>
+
     <!-- 中央ロゴ -->
+    <div class="app-header__center">
       <%= link_to root_path, class: "app-header__logo-link" do %>
         <%= image_tag "haby-logo.png", alt: "haby logo", class: "app-header__logo" %>
       <% end %>
+    </div>
   </div>
+
+  <!-- 右端固定のハンバーガーボタン -->
+  <button
+    class="app-header__menu-button app-header__menu-button--fixed"
+    type="button"
+    aria-label="メニューを開閉"
+    aria-expanded="false"
+    aria-controls="global-nav"
+    id="js-hamburger-button">
+    <span class="app-header__menu-line"></span>
+    <span class="app-header__menu-line"></span>
+    <span class="app-header__menu-line"></span>
+  </button>
+
+  <!-- ハンバーガーで開くメニュー -->
+  <nav class="app-header__nav" id="global-nav">
+    <ul class="app-header__nav-list">
+      <li><a href="#" class="app-header__nav-link">habyとは</a></li>
+      <li><a href="#" class="app-header__nav-link">使い方</a></li>
+      <li><a href="#" class="app-header__nav-link">新規登録/ログイン</a></li>
+      <li><a href="#" class="app-header__nav-link">その他</a></li>
+    </ul>
+  </nav>
 </header>


### PR DESCRIPTION
## 概要
ヘッダー右上にハンバーガーメニューを実装し、右から左にスライドするメニューを追加しました。  

## 目的
- スマホ利用時でもヘッダーから主要メニューにアクセスしやすくするため
- 既存のボトムナビゲーションを維持しつつ、ヘッダー側にもメニューを用意して画面の遷移を容易にするため

## 作業内容
- ヘッダー部分のマークアップ修正
- スタイルの追加・調整
- ハンバーガーメニュー用 JavaScript の実装

## 確認事項
- [x] トップページ表示時に、ヘッダー中央にロゴ・右上にハンバーガーアイコンが表示されること
- [x] ハンバーガーアイコンをクリックすると、アイコンが「X」マークに変化し、右からメニューがスライドインすること
- [x] メニュー外をクリックすると、メニューが閉じてアイコンが元の3本線に戻ること
- [x] メニュー内のリンクをクリックしたあと、遷移先のページでもリロードせずにハンバーガーメニューが再度動作すること
- [x] 既存のボトムナビゲーションの表示・動作に影響がないこと

## 関連issue
- #19 ヘッダーにハンバーガーメニューを実装する

## 備考
-  今後、各ページの実装状況に合わせてlink_toへの差し替えや遷移先の調整を行う予定です。
