### PR TITLE
feat:習慣の新規登録機能を実装

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,0 +1,26 @@
+class HabitsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @habits = current_user.habits.order(created_at: :desc)
+    @habit  = current_user.habits.build
+  end
+
+  def create
+    @habit = current_user.habits.build(habit_params)
+
+    if @habit.save
+      redirect_to habits_path, notice: "習慣を登録しました！"
+    else
+      @habits = current_user.habits.order(created_at: :desc)
+      flash.now[:alert] = "入力内容を確認してください"
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def habit_params
+    params.require(:habit).permit(:name, :detail)
+  end
+end

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -1,0 +1,33 @@
+<h1>習慣</h1>
+
+<%= form_with model: @habit, url: habits_path do |f| %>
+  <% if @habit.errors.any? %>
+    <div>
+      <ul>
+        <% @habit.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :name, "習慣名（必須）" %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :detail, "詳細" %>
+    <%= f.text_area :detail %>
+  </div>
+
+  <%= f.submit "追加" %>
+<% end %>
+
+<hr>
+
+<ul>
+  <% @habits.each do |habit| %>
+    <li><%= habit.name %></li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :habits, only: %i[new create index]
+
   root "home#index"
   get "home/index"
 


### PR DESCRIPTION
## 概要
習慣を新規登録できる機能を実装しました。（一旦new画面は作らず、既存画面のフォームからcreateのみで登録）

## 目的
ユーザーが続けたい習慣をアプリ上に追加し、記録の対象として管理できるようにするため。

## 作業内容
- HabitsController#create を実装
- current_userに紐づけて Habit を保存するように実装
- 成功時はフラッシュ表示 + リダイレクト
- 失敗時はバリデーションエラーを表示できるように対応

## 確認事項
- [ ] ログインユーザーが習慣を新規追加できる
- [ ] 必須項目未入力時にエラーメッセージが表示される
- [ ] 登録成功時にフラッシュが表示され、想定の画面へ遷移する

## 関連issue
- close #22 

## 備考
- newアクション/画面は今後習慣の設定項目が増えた際に画面分離させるため作成予定。
