### PR TITLE
習慣一覧・詳細機能の実装

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -3,7 +3,10 @@ class HabitsController < ApplicationController
 
   def index
     @habits = current_user.habits.order(created_at: :desc)
-    @habit  = current_user.habits.build
+  end
+
+  def new
+    @habit = current_user.habits.build
   end
 
   def create
@@ -16,6 +19,10 @@ class HabitsController < ApplicationController
       flash.now[:alert] = "入力内容を確認してください"
       render :index, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @habit = current_user.habits.find(params[:id])
   end
 
   private

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -1,33 +1,8 @@
 <h1>習慣</h1>
 
-<%= form_with model: @habit, url: habits_path do |f| %>
-  <% if @habit.errors.any? %>
-    <div>
-      <ul>
-        <% @habit.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= f.label :name, "習慣名（必須）" %>
-    <%= f.text_field :name %>
-  </div>
-
-  <div>
-    <%= f.label :detail, "詳細" %>
-    <%= f.text_area :detail %>
-  </div>
-
-  <%= f.submit "追加" %>
-<% end %>
-
-<hr>
-
 <ul>
   <% @habits.each do |habit| %>
-    <li><%= habit.name %></li>
+    <%= link_to habit.name, habit_path(habit) %>
   <% end %>
 </ul>
+<%= link_to "習慣を追加", new_habit_path %>

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -1,0 +1,19 @@
+<h1>習慣を追加</h1>
+
+<%= form_with model: @habit do |f| %>
+  <div>
+    <%= f.label :name, "習慣名" %><br>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :detail, "詳細" %><br>
+    <%= f.text_area :detail %>
+  </div>
+
+  <div>
+    <%= f.submit "追加する" %>
+  </div>
+<% end %>
+
+<p><%= link_to "一覧に戻る", habits_path %></p>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @habit.name %></h1>
+
+<p><%= simple_format(@habit.detail) %></p>
+
+<p><%= link_to "一覧に戻る", habits_path %></p>

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -16,8 +16,8 @@
     <span class="bottom-nav__label">カレンダー</span>
   <% end %>
 
-  <%= link_to manage_path,
-              class: "bottom-nav__item #{'bottom-nav__item--active' if current_page?(manage_path)}" do %>
+  <%= link_to habits_path,
+              class: "bottom-nav__item #{'bottom-nav__item--active' if current_page?(habits_path)}" do %>
     <div class="bottom-nav__icon-wrapper">
       <%= image_tag "icons/manage.png", class: "bottom-nav__icon", alt: "" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :habits, only: %i[new create index]
+  resources :habits, only: %i[new create index show]
 
   root "home#index"
   get "home/index"


### PR DESCRIPTION
## 概要
習慣の一覧・詳細表示、新規作成画面への導線を追加しました。

## 目的
ユーザーが登録した習慣を一覧で確認し、詳細情報も確認できるようにするため。
また、後に実装する編集・削除へ繋げる基盤を整えるため。

## 作業内容
- HabitsController に show / new を実装
- current_user に紐づく習慣のみ取得するよう制御
- 習慣一覧ページを作成
- 習慣詳細ページを作成
- 一覧ページに「習慣を追加」リンクを設置し、new画面へ遷移できるように対応
- 習慣新規作成ページを作成

## 確認事項
- ログインユーザーの習慣一覧が表示されること
- 一覧から詳細ページに遷移し、習慣の情報が表示されること
- 他ユーザーの習慣IDをURL直打ちしても閲覧できず RecordNotFound になること
- new から作成後、一覧に表示されること

## 関連issue
- close #23 

## 備考
- なし
