### PR TITLE
重複ルーティングの解消

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,6 @@ class PagesController < ApplicationController
   ]
 
   def calendar; end
-  def habits; end
   def manage; end
 
   # マイページ

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/shared/_bottom_nav.html.erb -->
 <nav class="bottom-nav">
-  <%= link_to habits_path,
-              class: "bottom-nav__item #{'bottom-nav__item--active' if current_page?(habits_path)}" do %>
+  <%= link_to home_index_path,
+              class: "bottom-nav__item #{'bottom-nav__item--active' if current_page?(home_index_path)}" do %>
     <div class="bottom-nav__icon-wrapper">
       <%= image_tag "icons/checkbox.png", class: "bottom-nav__icon", alt: "" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
   get "contact",  to: "static_pages#contact"
 
   get "calendar", to: "pages#calendar"
-  get "habits", to: "pages#habits"
   get "manage", to: "pages#manage"
 
   # マイページ


### PR DESCRIPTION
## 概要
habitsに関するルーティングの重複を解消しました。

## 目的
PagesControllerとHabitsControllerの2つが存在しており、同じhabit_pathを使用していたため。

## 作業内容
- resources :habitsによる CRUD 用ルーティングを残す
- get "habits", to: "pages#habits" を削除し、重複ルーティングを解消
- habits 一覧はHabitsController#indexに集約

## 確認事項
- /habits が HabitsController#indexに正しくルーティングされること
- 習慣の新規作成・一覧表示・詳細表示が正常に動作すること
- ナビゲーションのリンクが habits_pathを参照していること

## 関連issue
なし

## 備考
今後の残りのCRUD実装を見据えたルーティング整理です。
