### PR TITLE
習慣編集機能の実装

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,5 +1,6 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_habit, only: %i[show edit update]
 
   def index
     @habits = current_user.habits.order(created_at: :desc)
@@ -25,7 +26,24 @@ class HabitsController < ApplicationController
     @habit = current_user.habits.find(params[:id])
   end
 
+  def edit
+  end
+
+  def update
+    if @habit.update(habit_params)
+      redirect_to habits_path(@habit), notice: "習慣を更新しました"
+    else
+      flash.now[:alert] = "更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+
   private
+
+  def set_habit
+    @habit = current_user.habits.find(params[:id])
+  end
 
   def habit_params
     params.require(:habit).permit(:name, :detail)

--- a/app/views/habits/_form.html.erb
+++ b/app/views/habits/_form.html.erb
@@ -1,0 +1,26 @@
+<!-- app/views/habits/_form.html.erb -->
+<%= form_with model: habit do |f| %>
+  <% if habit.errors.any? %>
+    <ul>
+      <% habit.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div>
+    <%= f.label :name, "習慣名" %><br>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :detail, "詳細" %><br>
+    <%= f.text_area :detail %>
+  </div>
+
+  <div>
+    <%= f.submit "追加する" %>
+  </div>
+<% end %>
+
+<p><%= link_to "一覧に戻る", habits_path %></p>

--- a/app/views/habits/edit.html.erb
+++ b/app/views/habits/edit.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/habits/edit.html.erb -->
+<h1>習慣を編集</h1>
+<%= render "form", habit: @habit %>

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -1,19 +1,3 @@
+<!-- app/views/habits/new.html.erb -->
 <h1>習慣を追加</h1>
-
-<%= form_with model: @habit do |f| %>
-  <div>
-    <%= f.label :name, "習慣名" %><br>
-    <%= f.text_field :name %>
-  </div>
-
-  <div>
-    <%= f.label :detail, "詳細" %><br>
-    <%= f.text_area :detail %>
-  </div>
-
-  <div>
-    <%= f.submit "追加する" %>
-  </div>
-<% end %>
-
-<p><%= link_to "一覧に戻る", habits_path %></p>
+<%= render "form", habit: @habit %>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -1,5 +1,5 @@
 <h1><%= @habit.name %></h1>
 
 <p><%= simple_format(@habit.detail) %></p>
-
+<p><%= link_to "編集", edit_habit_path(@habit) %>
 <p><%= link_to "一覧に戻る", habits_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :habits, only: %i[new create index show]
+  resources :habits, only: %i[new create index show edit update]
 
   root "home#index"
   get "home/index"


### PR DESCRIPTION
## 概要
習慣の編集機能を実装しました。

## 目的
登録済みの習慣をユーザーが後から修正できるようにするため。

## 作業内容
- 習慣編集画面の実装
- 習慣更新処理の実装
- newとeditで共通利用できるフォームを作成
- ストロングパラメーターを用いた制御処理
- current_userに紐づく習慣のみ取得するよう制限を追加
- 更新成功・失敗時の遷移とフラッシュメッセージの設定

## 確認事項
- [ ] 編集画面がエラーなく表示されること
- [ ] 習慣名・詳細を変更して保存できること
- [ ] バリデーションエラー時に edit 画面へ戻り、エラーメッセージが表示されること
- [ ] 他ユーザーの習慣IDを指定した場合、編集できないこと

## 関連issue
- close #24 

## 備考
なし
