### PR TITLE
カレンダー土台の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "jbuilder"
 gem "rails-i18n", "~> 7.0"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
+gem "simple_calendar"
+
 gem "devise"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -385,6 +387,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails-omakase
   selenium-webdriver
+  simple_calendar
   sprockets-rails
   stimulus-rails
   turbo-rails
@@ -509,6 +512,7 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.39.0) sha256=984a1e63d39472eaf286bac3c6f1822fa7eea6eed9c07a66ce7b3bc5417ba826
+  simple_calendar (3.1.0) sha256=56764606c3804c70e6facb47b6571ec79d7ce941e77b6bd3678869c1350a720c
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,6 +5,7 @@
  *= require components/buttons
  *= require components/header
  *= require components/footer
+ *= require components/haby_calendar
  *= require components/bottom_nav
  *= require pages/home
  *= require pages/devise

--- a/app/assets/stylesheets/components/buttons.css
+++ b/app/assets/stylesheets/components/buttons.css
@@ -42,6 +42,7 @@
   box-shadow:
     0 10px 20px rgba(0,0,0,0.15),
     0 3px 6px rgba(255,255,255,0.85) inset;
+  cursor: pointer;
 }
 
 .btn-primary:active,

--- a/app/assets/stylesheets/components/haby_calendar.css
+++ b/app/assets/stylesheets/components/haby_calendar.css
@@ -1,0 +1,136 @@
+:root{
+  --haby-primary: #117BBF;
+  --haby-primary-soft: rgba(17,123,191,0.10);
+  --haby-border: rgba(0,0,0,0.08);
+  --haby-text: rgba(0,0,0,0.86);
+  --haby-muted: rgba(0,0,0,0.45);
+}
+
+/* 外枠 */
+.simple-calendar.haby-cal{
+  background:#fff;
+  border:1px solid var(--haby-border);
+  border-radius:18px;
+  padding:30px;
+}
+
+/* header */
+.haby-cal__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:12px;
+}
+
+.haby-cal__title{
+  font-size:20px;
+  font-weight:900;
+  color:var(--haby-text);
+  letter-spacing:.2px;
+}
+
+/* nav buttons */
+.haby-cal__nav{ display:flex; gap:8px; }
+
+.haby-cal__nav-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:8px 10px;
+  border-radius:12px;
+  border:1px solid rgba(0,0,0,0.10);
+  background:#fff;
+  text-decoration:none;
+  color:var(--haby-text);
+  font-weight:800;
+  font-size:13px;
+}
+
+.haby-cal__nav-btn--ghost{
+  background:rgba(0,0,0,0.02);
+  border-color:rgba(0,0,0,0.06);
+}
+
+/* table reset */
+.haby-cal__table{
+  width:100%;
+  border-collapse:separate;
+  border-spacing:8px; /* “マス目の隙間”を作る */
+}
+
+/* weekday header */
+.haby-cal__weekday{
+  text-align:center;
+  font-size:15px;
+  font-weight:800px;
+  color:var(--haby-muted);
+  padding:6px 0;
+}
+
+/* cells */
+.haby-cal__cell{
+  border-radius: 30px;
+  border:3px solid rgba(0,0,0,0.06);
+  background:rgba(0,0,0,0.01);
+  vertical-align:top;
+  min-height:48px;
+  height:120px;
+  padding:10px;
+  overflow:hidden;
+}
+
+.haby-cal__cell-inner{
+  padding:8px;
+  height:100%;
+}
+
+.haby-cal__date{
+  font-size:13px;
+  font-weight:900;
+  color:var(--haby-text);
+}
+
+.simple-calendar .today.haby-cal__cell{
+  border-color: rgba(17,123,191,0.45);
+  background: var(--haby-primary-soft);
+  box-shadow: 0 0 0 2px rgba(17,123,191,0.10) inset;
+}
+
+.simple-calendar .not-current-month.haby-cal__cell{
+  opacity:.35;
+}
+
+/* 中身（将来：実施状況のバッジ等） */
+.haby-cal__content{
+  margin-top:6px;
+}
+
+/* 動き（基本） */
+.haby-cal__cell{
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease;
+  will-change: transform;
+}
+
+/* PC: hover */
+@media (hover: hover) and (pointer: fine){
+  .haby-cal__cell:hover{
+    transform: translateY(-2px);
+    box-shadow: 0 10px 18px rgba(0,0,0,0.08);
+    border-color: rgba(17,123,191,0.22);
+  }
+}
+
+/* スマホ: 押した瞬間 */
+.haby-cal__cell:active{
+  transform: scale(0.98);
+}
+
+/* レスポンシブ */
+@media (max-width: 420px){
+  .simple-calendar.haby-cal{ padding:12px; border-radius:16px; }
+  .haby-cal__table{ border-spacing:5px; }
+  .haby-cal__cell{ height:64px; }
+  .haby-cal__cell-inner{ padding:6px; }
+  .haby-cal__title{ font-size:15px; }
+}

--- a/app/views/pages/calendar.html.erb
+++ b/app/views/pages/calendar.html.erb
@@ -1,2 +1,6 @@
-<h1>Pages#calendar</h1>
-<p>Find me in app/views/pages/calendar.html.erb</p>
+<div class="calendar-page">
+  <div class="calendar-page__container">
+    <%= month_calendar do |_date| %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,49 @@
+<div class="simple-calendar haby-cal">
+  <div class="haby-cal__header">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="haby-cal__title">
+      <%= start_date.strftime("%Y年%-m月") %>
+    </time>
+
+    <nav class="haby-cal__nav">
+      <%= link_to "←", calendar.url_for_previous_view, class: "haby-cal__nav-btn" %>
+      <%= link_to "今日", calendar.url_for_today_view, class: "haby-cal__nav-btn haby-cal__nav-btn--ghost" %>
+      <%= link_to "→", calendar.url_for_next_view, class: "haby-cal__nav-btn" %>
+    </nav>
+  </div>
+
+  <table class="haby-cal__table">
+    <thead>
+      <tr class="haby-cal__weekdays">
+        <% # 月曜始まりにしたい場合はここを固定表示にするのが確実 %>
+        <% %w[月 火 水 木 金 土 日].each do |w| %>
+          <th class="haby-cal__weekday"><%= w %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody class="haby-cal__body">
+      <% date_range.each_slice(7) do |week| %>
+        <tr class="haby-cal__row">
+          <% week.each do |day| %>
+            <% td_class = calendar.td_classes_for(day) %>
+            <% # simple_calendarのclassに加えて、haby用classも足す %>
+            <% classes = ["haby-cal__cell", td_class] %>
+
+            <%= content_tag :td, class: classes.join(" ") do %>
+              <div class="haby-cal__cell-inner">
+                <div class="haby-cal__date">
+                  <%= day.day %>
+                </div>
+
+                <%# ここは将来の実施状況表示用の枠（今は空でOK） %>
+                <div class="haby-cal__content">
+                  <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title">
+      <%= t('simple_calendar.week', default: 'Week') %>
+      <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
## 概要
simple_calendarを使用して、1ヶ月表示のカレンダーUIの土台を実装しました。
またhabyのデザインに合わせた装飾を行い、セルに軽いアニメーションを加えています。

## 目的
習慣・服薬の実施状況を日付単位で見やすくし、カレンダー機能のベースを作成するため。

## 作業内容
- simple_calendarを導入
- month_calendarを用いた1ヶ月表示カレンダーを実装
- simple_calendar の月表示用テンプレート（_month_calendar.html.erb）をカスタマイズ
- 曜日ヘッダー・日付表示を実装
- 当日セルの強調表示
- haby全体のトーンに合わせたカラーデザインを適用
- レスポンシブ対応

## 確認事項
- /calendarで当月のカレンダーが表示されること
- 前月 / 今日 / 翌月 のナビゲーションが正しく動作すること
- 当日セルが強調表示されていること
- CSSが正しく適用され、PC・スマホ双方で表示が崩れないこと

## 関連issue
- close #30 カレンダー土台の実装(1ヶ月表示)

## 備考
- カレンダーの表示・デザインまでを対象とし、実施状況の表示は今後のIssueで対応予定です。
