### PR TITLE
カレンダーに実施記録を表示

### DIFF
--- a/app/assets/stylesheets/components/haby_calendar.css
+++ b/app/assets/stylesheets/components/haby_calendar.css
@@ -57,13 +57,15 @@
   width:100%;
   border-collapse:separate;
   border-spacing:8px; /* “マス目の隙間”を作る */
+  table-layout: fixed;
+  width: 100%;
 }
 
 /* weekday header */
 .haby-cal__weekday{
   text-align:center;
   font-size:15px;
-  font-weight:800px;
+  font-weight:800;
   color:var(--haby-muted);
   padding:6px 0;
 }
@@ -83,18 +85,14 @@
 .haby-cal__cell-inner{
   padding:8px;
   height:100%;
+  display:flex;
+  flex-direction:column;
 }
 
 .haby-cal__date{
   font-size:13px;
   font-weight:900;
   color:var(--haby-text);
-}
-
-.simple-calendar .today.haby-cal__cell{
-  border-color: rgba(17,123,191,0.45);
-  background: var(--haby-primary-soft);
-  box-shadow: 0 0 0 2px rgba(17,123,191,0.10) inset;
 }
 
 .simple-calendar .not-current-month.haby-cal__cell{
@@ -110,6 +108,9 @@
 .haby-cal__cell{
   transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease;
   will-change: transform;
+  /* 外側セル（td）の基本枠 */
+  
+  box-sizing: border-box;
 }
 
 /* PC: hover */
@@ -134,3 +135,46 @@
   .haby-cal__cell-inner{ padding:6px; }
   .haby-cal__title{ font-size:15px; }
 }
+
+
+.haby-cal__cell .haby-cal__cell-inner {
+  border: none;
+  box-shadow: none;
+  background: #fff;
+  padding: 8px;
+  border-radius: 10px;
+}
+
+/* 全部達成 */
+.haby-cal__cell.cal-day--all {
+  border-color: rgba(17, 132, 59, 0.85);
+}
+
+/* 一部達成 */
+.haby-cal__cell.cal-day--partial {
+  border-color: rgba(123, 201, 102, 0.85);
+}
+
+/* 未達成 */
+.haby-cal__cell.cal-day--none {
+
+}
+
+.haby-cal__complete {
+  display: inline-block;
+
+  margin: 6px 0 0;        
+  align-self: center;
+
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+
+  color: #fff;
+  background-color: rgba(17, 132, 59, 0.85);
+
+  padding: 2px 8px;
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,39 @@ class PagesController < ApplicationController
     :confirm_delete_account, :destroy_account
   ]
 
-  def calendar; end
+  def calendar
+    base_date =
+      if params[:start_date].present?
+        Date.parse(params[:start_date])
+      else
+        Date.current
+      end
+
+    from = base_date.beginning_of_month
+    to   = base_date.end_of_month
+
+    logs = current_user.habit_logs.where(log_date: from..to)
+
+    logs_by_date = logs.group_by(&:log_date)
+
+    @day_class = {}
+    logs_by_date.each do |date, day_logs|
+      total = day_logs.size
+      taken = day_logs.count { |l| l.is_taken }
+
+      @day_class[date] =
+        if taken == total
+          "cal-day--all"
+        elsif taken == 0
+          "cal-day--none"
+        else
+          "cal-day--partial"
+        end
+    end
+  end
+
+
+
   def manage; end
 
   # マイページ

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -26,16 +26,19 @@
         <tr class="haby-cal__row">
           <% week.each do |day| %>
             <% td_class = calendar.td_classes_for(day) %>
-            <% # simple_calendarのclassに加えて、haby用classも足す %>
-            <% classes = ["haby-cal__cell", td_class] %>
+            <% result_class = @day_class&.[](day.to_date) %>
+            <% classes = ["haby-cal__cell", td_class, result_class].compact %>
 
             <%= content_tag :td, class: classes.join(" ") do %>
               <div class="haby-cal__cell-inner">
                 <div class="haby-cal__date">
                   <%= day.day %>
                 </div>
-
-                <%# ここは将来の実施状況表示用の枠（今は空でOK） %>
+              <% if @day_class&.[](day.to_date) == "cal-day--all" %>
+                <div class="haby-cal__complete">
+                  complete!
+                </div>
+              <% end %>
                 <div class="haby-cal__content">
                   <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
                 </div>


### PR DESCRIPTION
## 概要
HabitLogの実施状況をもとに、カレンダー上で習慣の達成状態を視覚的に確認できるようにしました。

## 目的
習慣の継続状況を一目で把握できるようにし、達成のモチベーション向上につなげるため。

## 作業内容
- 指定月のHabitLogを一括取得
- 日付ごとにis_takenを集計し、達成状態を判定
- セルに状態クラスを付与
- 達成状況に応じてセル枠を色分け
- 全習慣達成時のみ「complete!」バッジを表示

## 確認事項
- [x] 習慣ログがある日付に枠色が表示される
- [x] 全達成／一部達成／未達成で表示が切り替わる
- [x] 月移動時も正しく表示される
- [x] UI崩れが発生していないことを確認

## 関連issue
- close #31 

## 備考
なし
