### PR TITLE
フラッシュメッセージの共通化と修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -7,6 +7,7 @@
  *= require components/footer
  *= require components/haby_calendar
  *= require components/bottom_nav
+ *= require components/flash
  *= require pages/home
  *= require pages/devise
  *= require pages/account

--- a/app/assets/stylesheets/components/flash.css
+++ b/app/assets/stylesheets/components/flash.css
@@ -1,0 +1,71 @@
+/* flash */
+.flash {
+  max-width: 640px;
+  margin: 12px auto;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.flash__message {
+  margin: 0;
+  font-weight: 700;
+}
+
+/* success: 緑 */
+.flash--success {
+  background: #eaf7ef;
+  border-color: #bfe6cc;
+  color: #1f6b3a;
+}
+
+/* danger: 赤 */
+.flash--danger {
+  background: #fdecec;
+  border-color: #f5bcbc;
+  color: #9b1c1c;
+}
+
+/* info */
+.flash--info {
+  background: #eef5ff;
+  border-color: #c4dcff;
+  color: #124a9a;
+}
+
+/* form errors block */
+.form-errors {
+  border-radius: 14px;
+  padding: 12px 14px;
+  margin: 12px 0 16px;
+  background: #fdecec;
+  border: 1px solid #f5bcbc;
+  color: #9b1c1c;
+}
+
+.form-errors__title {
+  margin: 0 0 8px;
+  font-weight: 900;
+  font-size: 14px;
+}
+
+.form-errors__list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.form-errors__item {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+/* rails default wrapper */
+.field_with_errors .habit-form__input,
+.field_with_errors input,
+.field_with_errors textarea,
+.field_with_errors select {
+  border-color: #f5bcbc !important;
+  background: #fff7f7;
+}

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -4,6 +4,8 @@ class HabitsController < ApplicationController
 
   def index
     @habits = current_user.habits.order(created_at: :desc)
+    prepare_index
+    @habit = Habit.new
     today_logs = HabitLog
     .where(user_id: current_user.id, habit_id: @habits.ids, log_date: Date.current)
     .index_by(&:habit_id)
@@ -19,10 +21,9 @@ class HabitsController < ApplicationController
     @habit = current_user.habits.build(habit_params)
 
     if @habit.save
-      redirect_to habits_path, notice: "習慣を登録しました！"
+      redirect_to habits_path, notice: "習慣を追加しました"
     else
-      @habits = current_user.habits.order(created_at: :desc)
-      flash.now[:alert] = "入力内容を確認してください"
+      prepare_index
       render :index, status: :unprocessable_entity
     end
   end
@@ -56,5 +57,13 @@ class HabitsController < ApplicationController
 
   def habit_params
     params.require(:habit).permit(:name, :detail)
+  end
+
+  def prepare_index
+    @habits = current_user.habits.order(created_at: :desc)
+
+    today = Date.current
+    logs = HabitLog.where(user_id: current_user.id, log_date: today, habit_id: @habits.pluck(:id))
+    @today_logs_by_habit_id = logs.index_by(&:habit_id)
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,6 @@
     <h2 class="auth-title">ログイン</h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="field">
         <%= f.label :email, "メールアドレス" %><br/>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,1 @@
-<% if resource.errors.any? %>
-  <div class="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render "shared/form_errors", model: resource %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,25 +20,19 @@
   </head>
 
   <body>
-    <% if notice %>
-      <p class="notice"><%= notice %></p>
-    <% end %>
-
-    <% if alert %>
-      <p class="alert"><%= alert %></p>
-    <% end %>
-
   <div class="app">
     <%= render "shared/header" %>
 
     <main class="app-main">
-    <%= yield %>
+      <div class="app-container">
+        <%= render "shared/flash" %>
+        <%= yield %>
+      </div>
     </main>
 
     <%= render "shared/footer" %>
   </div>
 
   <%= render "shared/bottom_nav" %>
-
-  </body>
+</body>
 </html>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,16 @@
+<% flash.each do |type, message| %>
+  <% next if message.blank? %>
+
+  <% css_type =
+    case type.to_s
+    when "notice" then "flash--success"
+    when "alert"  then "flash--danger"
+    when "error"  then "flash--danger"
+    else               "flash--info"
+    end
+  %>
+
+  <div class="flash <%= css_type %>" role="status">
+    <p class="flash__message"><%= message %></p>
+  </div>
+<% end %>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,0 +1,10 @@
+<% if model.errors.any? %>
+  <div class="form-errors" role="alert">
+    <p class="form-errors__title">入力内容を確認してください</p>
+    <ul class="form-errors__list">
+      <% model.errors.full_messages.each do |msg| %>
+        <li class="form-errors__item"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
フラッシュメッセージおよびフォームエラー表示のUIを共通化し、全画面で統一された表示になるように整理しました。

## 目的
ユーザー操作の結果が直感的に分かるようにし、エラーを見やすくするため。

## 作業内容
- shared/_flash.html.erbを作成し、フラッシュ表示を共通化
- application.html.erbに残っていたnotice / alertの直書き表示を削除
- フォームのバリデーションエラー表示を整理し、二重表示を解消

## 確認事項
- [ ] 登録・更新・削除成功時にフラッシュ（緑）が1回のみ表示されること
- [ ] バリデーション失敗時にフォームエラーが1回のみ表示されること
- [ ] Devise のログイン失敗時にフラッシュ（赤）が正しく表示されること

## 関連issue
- フラッシュメッセージとフォームエラー表示の全体スタイル統一

## 備考
