### PR TITLE
全体デザインの見た目の修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,5 +1,6 @@
 /*
  *= require_self
+ *= require base/reset
  *= require base/variables
  *= require base/layout
  *= require components/buttons

--- a/app/assets/stylesheets/base/layout.css
+++ b/app/assets/stylesheets/base/layout.css
@@ -1,7 +1,3 @@
-:root {
-  --bottom-nav-height: 110px;
-}
-
 .app {
   min-height: 100vh;
   display: flex;
@@ -9,9 +5,17 @@
 }
 
 .app-main {
-  padding-bottom: calc(var(--bottom-nav-height) + 24px);
+  flex: 1;
+  padding-bottom: calc(var(--bottom-nav-height) + var(--space-4));
 }
 
-*, *::before, *::after {
-  box-sizing: border-box;
+html, body {
+  overflow-x: hidden;
+}
+
+
+@supports not (overflow-x: clip) {
+  html, body {
+    overflow-x: hidden;
+  }
 }

--- a/app/assets/stylesheets/base/reset.css
+++ b/app/assets/stylesheets/base/reset.css
@@ -1,0 +1,3 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}

--- a/app/assets/stylesheets/base/variables.css
+++ b/app/assets/stylesheets/base/variables.css
@@ -1,5 +1,51 @@
 :root {
+  /* Brand */
   --brand: #117BBF;
+
+  /* Layout */
   --bottom-nav-height: 80px;
-  --header-height: 74px;
+  --header-height: 70px;
+  --container-max: 960px;
+
+  /* Background / Surface */
+  --bg: #ffffff;
+  --surface: #f7fafc;        /* カード背景 */
+  --surface-2: #f1f5f9;      /* 薄いセクション背景 */
+
+  /* Text */
+  --text: #111827;
+  --text-muted: #6b7280;
+  --text-inverse: #ffffff;
+
+  /* Border / Shadow */
+  --border: #e5e7eb;
+  --shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+
+  /* Radius */
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+
+  /* Spacing */
+  --space-1: 6px;
+  --space-2: 10px;
+  --space-3: 14px;
+  --space-4: 18px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  /* Typography */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+               "Noto Sans JP", sans-serif;
+  --font-size-base: 15px;
+  --line-height: 1.6;
+
+  /* State colors */
+  --danger: #ef4444;
+  --success: #22c55e;
+  --warning: #f59e0b;
+
+  /* Brand variations (便利) */
+  --brand-weak: #e8f3fb;
+  --brand-hover: #0e6aa5;
 }

--- a/app/assets/stylesheets/components/bottom_nav.css
+++ b/app/assets/stylesheets/components/bottom_nav.css
@@ -36,10 +36,13 @@
 }
 
 .bottom-nav__icon {
-  display: inline-block;
-  font-size: 24px;
-  line-height: 1;
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
 }
+
 
 /* アクティブ */
 .bottom-nav__item--active {

--- a/app/assets/stylesheets/components/buttons.css
+++ b/app/assets/stylesheets/components/buttons.css
@@ -1,57 +1,64 @@
-/* ボタン */
+/* Buttons */
 
-.btn-primary {
-  background-color: #117BBF;
-  color: #fff;
-}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 
-.btn-secondary {
-  background-color: #efefef;
-  color: #333;
-}
-
-.btn-primary,
-.btn-secondary {
-  display: inline-block;
   padding: 16px 32px;
   font-size: 18px;
   border-radius: 14px;
   font-weight: 600;
+
+  border: none;
+  text-decoration: none;
+  line-height: 1;
+  white-space: nowrap;
+
   transition:
     transform 0.18s cubic-bezier(0.17, 0.67, 0.37, 1.32),
     box-shadow 0.18s ease,
     background-color 0.18s ease;
+
   box-shadow:
     0 6px 15px rgba(0, 0, 0, 0.10),
     0 2px 4px rgba(255, 255, 255, 0.8) inset;
+
+  cursor: pointer;
 }
 
-.btn-primary {
-  background: linear-gradient(180deg, #1ea0ff, #117BBF);
-  color: #fff;
-}
-
-.btn-secondary {
-  background: linear-gradient(180deg, #d6d8d8a3, #e9e9e9);
-  color: #333;
-}
-
-.btn-primary:hover,
-.btn-secondary:hover {
+.btn:hover {
   transform: translateY(-3px) scale(1.03);
   box-shadow:
     0 10px 20px rgba(0,0,0,0.15),
     0 3px 6px rgba(255,255,255,0.85) inset;
-  cursor: pointer;
 }
 
-.btn-primary:active,
-.btn-secondary:active {
+.btn:active {
   transform: translateY(1px) scale(0.95);
   box-shadow:
     0 2px 4px rgba(0,0,0,0.25) inset,
     0 0 0 rgba(0,0,0,0.1);
 }
+
+/* Variants */
+.btn--primary {
+  background: linear-gradient(180deg, #1ea0ff, #117BBF);
+  color: #fff;
+}
+
+.btn--secondary {
+  background: linear-gradient(180deg, #d6d8d8a3, #e9e9e9);
+  color: #333;
+}
+
+/* ログアウト用に */
+.btn--danger {
+  background: linear-gradient(180deg, #e93232, #ef4444);
+  color: #fff;
+}
+
 
 /* トグル全体 */
 .toggle-switch {

--- a/app/assets/stylesheets/components/footer.css
+++ b/app/assets/stylesheets/components/footer.css
@@ -48,3 +48,35 @@
 .app-footer__links a:hover {
   text-decoration: underline;
 }
+
+/* Footer: responsive */
+
+@media (max-width: 600px) {
+  .app-footer {
+    padding: 16px 0;
+    padding-bottom: calc(var(--bottom-nav-height) + 12px);
+    margin-top: 24px;
+  }
+
+  .app-footer__inner {
+    padding: 0 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .app-footer__copy {
+    text-align: left;
+    flex: none;
+    font-size: 13px;
+  }
+
+  .app-footer__links {
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .app-footer__links a {
+    font-size: 13px;
+  }
+}

--- a/app/assets/stylesheets/components/haby_calendar.css
+++ b/app/assets/stylesheets/components/haby_calendar.css
@@ -17,11 +17,14 @@
 /* 外枠 */
 .simple-calendar.haby-cal{
   background:#fff;
-  border:1px solid var(--haby-border);
+  border:1px solid rgba(17,123,191,0.14);
   border-radius:18px;
   padding:24px;
   max-width: 100%;
   overflow-x: hidden;
+  box-shadow:
+    0 10px 28px rgba(0,0,0,0.06),
+    0 1px 0 rgba(255,255,255,0.6) inset;
 }
 
 /* header */
@@ -34,10 +37,26 @@
 }
 
 .haby-cal__title{
+  position: relative;
+  padding-left: 12px;
   font-size:20px;
   font-weight:900;
   color:var(--haby-text);
   letter-spacing:.2px;
+  white-space: nowrap;
+}
+
+.haby-cal__title::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--haby-primary);
+  opacity: 0.9;
 }
 
 /* nav buttons */
@@ -49,20 +68,34 @@
   justify-content:center;
   padding:8px 10px;
   border-radius:12px;
-  border:1px solid rgba(0,0,0,0.10);
-  background:#fff;
+  border:1px solid rgba(17,123,191,0.18);
+  background: rgba(17,123,191,0.04);
   text-decoration:none;
   color:var(--haby-text);
   font-weight:800;
   font-size:13px;
+  box-shadow:
+    0 2px 0 rgba(0,0,0,0.04),
+    0 1px 0 rgba(255,255,255,0.65) inset;
+}
+
+.haby-cal__nav-btn:hover{
+  border-color: rgba(17,123,191,0.26);
+}
+
+.haby-cal__nav-btn:active{
+  transform: translateY(1px);
+  box-shadow:
+    0 1px 0 rgba(0,0,0,0.03),
+    0 1px 0 rgba(255,255,255,0.55) inset;
 }
 
 .haby-cal__nav-btn--ghost{
-  background:rgba(0,0,0,0.02);
+  background:#fff;
   border-color:rgba(0,0,0,0.06);
 }
 
-/* 例 */
+/* legend */
 .haby-cal__legend{
   display:flex;
   gap:8px;
@@ -79,8 +112,9 @@
   color: var(--haby-muted);
   padding:6px 10px;
   border-radius: 999px;
-  border:1px solid rgba(0,0,0,0.08);
+  border:1px solid rgba(0,0,0,0.06);
   background:#fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.05);
 }
 
 .haby-cal__legend-item::before{
@@ -95,7 +129,7 @@
 .haby-cal__legend-item--partial::before{ background: rgba(123, 201, 102, 0.95); }
 .haby-cal__legend-item--none::before{ background: rgba(0,0,0,0.28); }
 
-/* table reset */
+/* table */
 .haby-cal__table{
   width:100%;
   max-width: 100%;
@@ -104,18 +138,19 @@
   table-layout: fixed;
 }
 
-/* weekday header */
 .haby-cal__weekday{
   text-align:center;
   font-size:13px;
   font-weight:800;
   color:var(--haby-muted);
   padding:6px 0;
+  border-radius: 12px;
 }
 
-/* cells  */
+/* cells */
 .haby-cal__cell{
-  border-radius: 18px;
+  position: relative;
+  border-radius: 16px;
   border:2px solid rgba(0,0,0,0.06);
   background: rgba(0,0,0,0.01);
   vertical-align:top;
@@ -123,7 +158,6 @@
   height: 116px;
   overflow:hidden;
   box-sizing: border-box;
-
   transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease, background-color 120ms ease;
   will-change: transform;
 }
@@ -134,6 +168,7 @@
   flex-direction:column;
   padding:10px;
   background: transparent;
+  min-height: 48px;
 }
 
 .haby-cal__date{
@@ -158,7 +193,7 @@
 @media (hover: hover) and (pointer: fine){
   .haby-cal__cell:hover{
     transform: translateY(-2px);
-    box-shadow: 0 10px 18px rgba(0,0,0,0.08);
+    box-shadow: 0 12px 26px rgba(0,0,0,0.07);
     border-color: rgba(17,123,191,0.22);
   }
 }
@@ -167,7 +202,7 @@
   transform: scale(0.98);
 }
 
-/* ===== 実施状況 ===== */
+/* 実施状況 */
 .haby-cal__cell.cal-day--all{
   background: var(--cal-all);
   border-color: var(--cal-all-border);
@@ -182,14 +217,6 @@
   background: var(--cal-none);
   border-color: var(--cal-none-border);
 }
-
-
-.haby-cal__cell{ position: relative; }
-
-.haby-cal__cell.cal-day--all::after{ background: rgba(17, 132, 59, 0.85); }
-.haby-cal__cell.cal-day--partial::after{ background: rgba(123, 201, 102, 0.95); }
-.haby-cal__cell.cal-day--none::after{ background: rgba(0,0,0,0.28); }
-
 
 .haby-cal__complete{
   display: inline-flex;
@@ -207,34 +234,34 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
-/* ===== レスポンシブ ===== */
-/* ===== iPhone向け ===== */
+/* cell link */
+.haby-cal__cell-link {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.haby-cal__cell-link:hover .haby-cal__cell-inner {
+  background: rgba(17, 123, 191, 0.08);
+  border-radius: 12px;
+}
+
+/* ===== Responsive ===== */
 @media (max-width: 700px){
-
-
   .simple-calendar.haby-cal{
     padding: 12px;
     border-radius: 16px;
   }
 
-  .haby-cal__header{
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 10px;
-  }
-
   .haby-cal__title{
     font-size: 16px;
-    font-weight: 900;
-    white-space: nowrap;
   }
 
-  .haby-cal__nav{
-    gap: 6px;
-    flex-shrink: 0;
-  }
+  .haby-cal__nav{ gap: 6px; }
 
   .haby-cal__nav-btn{
     padding: 8px 10px;
@@ -242,12 +269,7 @@
     font-size: 12px;
   }
 
-  .haby-cal__legend{
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
-    margin: 0 0 10px;
-  }
+  .haby-cal__legend{ gap: 6px; }
 
   .haby-cal__legend-item{
     font-size: 11px;
@@ -255,11 +277,9 @@
   }
 
   .haby-cal__table{
-    width: 100%;
-    border-collapse: separate;
     border-spacing: 6px;
-    table-layout: fixed;
   }
+
   .haby-cal__weekdays{
     display: grid;
     grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -274,7 +294,6 @@
     padding: 6px 0;
     border-radius: 10px;
     background: rgba(0,0,0,0.02);
-    color: var(--haby-muted);
   }
 
   .haby-cal__body{
@@ -288,17 +307,12 @@
   }
 
   .haby-cal__cell{
-    position: relative;
     height: 48px;
     border-radius: 14px;
-    padding: 0;
-    overflow: hidden;
   }
 
   .haby-cal__cell-inner{
-    height: 100%;
     padding: 8px;
-    background: transparent;
   }
 
   .haby-cal__date{
@@ -306,107 +320,10 @@
     line-height: 1;
   }
 
-  .haby-cal__content{
-    display: none;
-  }
-
+  .haby-cal__content,
   .haby-cal__complete{
     display: none;
   }
-}
-
-.simple-calendar.haby-cal{
-  border-color: rgba(17,123,191,0.14);
-  box-shadow:
-    0 10px 28px rgba(0,0,0,0.06),
-    0 1px 0 rgba(255,255,255,0.6) inset;
-}
-
-
-.haby-cal__title{
-  position: relative;
-  padding-left: 12px;
-}
-
-.haby-cal__title::before{
-  content:"";
-  position:absolute;
-  left:0;
-  top:50%;
-  transform: translateY(-50%);
-  width: 6px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--haby-primary);
-  opacity: 0.9;
-}
-
-
-.haby-cal__nav-btn{
-  border-color: rgba(17,123,191,0.18);
-  background: rgba(17,123,191,0.04);
-  box-shadow:
-    0 2px 0 rgba(0,0,0,0.04),
-    0 1px 0 rgba(255,255,255,0.65) inset;
-}
-
-.haby-cal__nav-btn:hover{
-  border-color: rgba(17,123,191,0.26);
-}
-
-.haby-cal__nav-btn:active{
-  transform: translateY(1px);
-  box-shadow:
-    0 1px 0 rgba(0,0,0,0.03),
-    0 1px 0 rgba(255,255,255,0.55) inset;
-}
-
-
-.haby-cal__nav-btn--ghost{
-  background: #fff;
-  border-color: rgba(0,0,0,0.06);
-}
-
-
-.haby-cal__weekday{
-  border-radius: 12px;
-}
-
-
-.haby-cal__cell{
-  border-radius: 16px;
-}
-
-
-@media (hover: hover) and (pointer: fine){
-  .haby-cal__cell:hover{
-    box-shadow: 0 12px 26px rgba(0,0,0,0.07);
-  }
-}
-
-
-.haby-cal__legend-item{
-  border-color: rgba(0,0,0,0.06);
-  box-shadow: 0 2px 10px rgba(0,0,0,0.05);
-}
-
-.haby-cal__cell-link {
-  display: block;
-  width: 100%;
-  height: 100%;
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.haby-cal__cell-inner {
-  min-height: 48px;
-}
-
-.haby-cal__cell-link:hover .haby-cal__cell-inner {
-  background: rgba(17, 123, 191, 0.08);
-  border-radius: 12px;
 }
 
 @media (max-width: 480px) {

--- a/app/assets/stylesheets/components/header.css
+++ b/app/assets/stylesheets/components/header.css
@@ -3,6 +3,7 @@
 /* Header */
 
 .app-header {
+  overflow-x: clip;
   position: sticky;
   top: 0;
   z-index: 50;
@@ -10,24 +11,32 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
 }
 
+@supports not (overflow-x: clip) {
+  .app-header {
+    overflow-x: hidden;
+  }
+}
+
 .app-header__inner {
   max-width: 960px;
   margin: 0 auto;
-  padding: 12px 16px;
-  display: flex;
+  padding: 6px 16px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
 }
 
-/* 左はダミー幅（ロゴ中央寄せ用） */
 .app-header__left {
-  width: 40px;
+  justify-self: start;
+  width: auto;
 }
 
-/* 中央ロゴ */
 .app-header__center {
-  flex: 1;
-  display: flex;
-  justify-content: center;
+  justify-self: center;
+}
+
+.app-header__right {
+  justify-self: end;
 }
 
 .app-header__logo-link {
@@ -35,7 +44,7 @@
 }
 
 .app-header__logo {
-  height: 50px;
+  height: 40px;
   width: auto;
   display: block;
 }
@@ -50,7 +59,7 @@
 .app-header__menu-button {
   background: transparent;
   border: none;
-  padding: 14px;
+  padding: 2px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -58,8 +67,8 @@
 }
 
 .app-header__menu-line {
-  width: 44px;
-  height: 4px;
+  width: 38px;
+  height: 3px;
   border-radius: 999px;
   background-color: #117BBF;
   transition: transform 0.2s ease, opacity 0.2s ease;

--- a/app/assets/stylesheets/pages/account.css
+++ b/app/assets/stylesheets/pages/account.css
@@ -1,8 +1,8 @@
 /* マイページ全体 */
 .account-page {
-  max-width: 100%;
-  margin: 40px auto 80px;
-  padding: 24px 20px 32px;
+  width: min(92vw, 640px);
+  margin: 24px auto;
+  padding: 24px 16px;
   background: #ffffff;
   border-radius: 20px;
 
@@ -10,6 +10,7 @@
     0 12px 30px rgba(0, 0, 0, 0.06),
     0 2px 4px rgba(255, 255, 255, 0.7) inset;
 }
+
 
 .account-page__title {
   font-size: 24px;
@@ -32,18 +33,22 @@
 
 /* メニューリスト */
 .account-menu {
-  list-style: none;
-  margin: 0;
+  margin-top: 40px;
   padding: 0;
+  list-style: none;
 }
 
 .account-menu__item {
   margin-bottom: 12px;
 }
 
+/* メニューリンク */
 .account-menu__link {
   display: block;
-  width: 480px;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+
   padding: 14px 16px;
   border-radius: 14px;
   background: #f5fbff;
@@ -53,11 +58,9 @@
   text-decoration: none;
   margin: 0 auto;
 
-  /* 左にちょっとアイコンがあるっぽい余白 */
   position: relative;
   padding-left: 20px;
 
-  /* ふんわりした影 */
   box-shadow:
     0 4px 10px rgba(17, 123, 191, 0.08),
     0 0 0 1px rgba(17, 123, 191, 0.03);
@@ -66,6 +69,7 @@
     transform 0.1s ease,
     box-shadow 0.2s ease;
 }
+
 
 /* ホバー・フォーカス時の動き */
 .account-menu__link:hover,

--- a/app/assets/stylesheets/pages/account_forms.css
+++ b/app/assets/stylesheets/pages/account_forms.css
@@ -1,6 +1,4 @@
-/* ============================
-   メールアドレス変更ページ
-   ============================ */
+/* メールアドレス変更ページ */
 .account-form-page {
   max-width: 480px;
   margin: 40px auto 80px;
@@ -46,10 +44,11 @@
   font-size: 14px;
   outline: none;
   background: #f8fcff;
+  min-height: 44px;
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease,
-    back-ground 0.2s ease;
+    background 0.2s ease;
 }
 
 .account-form__input:focus {

--- a/app/assets/stylesheets/pages/devise.css
+++ b/app/assets/stylesheets/pages/devise.css
@@ -2,35 +2,35 @@
 
 .devise-main {
   padding: 20px;
-  max-width: 480px;
-  margin: 0 auto;
 }
 
+/* 外側：中央寄せ */
 .auth-wrapper {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  padding: 40px 20px;
+  padding: 32px 16px;
   width: 100%;
   box-sizing: border-box;
 }
 
+/* カード */
 .auth-card {
-  width: 100%;
-  max-width: 800px;
+  width: min(92vw, 520px);
   background: #fff;
-  padding: 32px 24px;
+  padding: 28px 20px;
   border-radius: 16px;
   box-shadow:
     0 4px 16px rgba(0, 0, 0, 0.08),
     0 0 0 1px rgba(17, 123, 191, 0.08);
 }
 
+/* タイトル */
 .auth-title {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
   color: #117BBF;
 }
 
@@ -52,7 +52,7 @@
   width: 100%;
   padding: 10px 12px;
   font-size: 14px;
-  border-radius: 8px;
+  border-radius: 10px;
   border: 1px solid #d0d7de;
   box-sizing: border-box;
 }
@@ -63,10 +63,11 @@
   box-shadow: 0 0 0 2px rgba(17, 123, 191, 0.15);
 }
 
+/* ボタン */
 .auth-button {
   width: 100%;
   border: none;
-  padding: 10px 12px;
+  padding: 12px 12px;
   border-radius: 999px;
   font-size: 15px;
   font-weight: 600;
@@ -83,26 +84,26 @@
   margin-top: 16px;
 }
 
+/* links */
 .auth-card a {
   color: #117BBF;
   font-size: 13px;
 }
 
-/* メモの小さい文字（パスワードの説明など） */
+/* メモの小さい文字 */
 .field-note {
   font-size: 12px;
   color: #6b7280;
   margin: 4px 0 6px;
 }
 
-/* remember_me の横並び */
+/* remember_me */
 .field-remember {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-/* Devise のリンク（パスワード忘れ・新規登録への導線など） */
 .auth-links {
   margin-top: 16px;
   text-align: center;
@@ -113,12 +114,7 @@
   margin: 4px 0;
 }
 
-.user-name {
-  font-size: 24px;
-  color: #676464
-}
-
-/* エラーメッセージのスタイル（devise/shared/error_messages） */
+/* エラーメッセージ */
 .error_explanation {
   margin-bottom: 16px;
   padding: 12px 14px;
@@ -142,4 +138,20 @@
 .error_explanation li {
   font-size: 13px;
   color: #b91c1c;
+}
+
+/* スマホ微調整 */
+@media (max-width: 480px) {
+  .auth-wrapper {
+    padding: 24px 12px;
+  }
+
+  .auth-card {
+    padding: 24px 16px;
+  }
+
+  .auth-title {
+    font-size: 20px;
+    margin-bottom: 16px;
+  }
 }

--- a/app/assets/stylesheets/pages/habit_form.css
+++ b/app/assets/stylesheets/pages/habit_form.css
@@ -1,6 +1,7 @@
 /* Habit Form */
 
-:root {
+/* 画面全体 */
+.habit-form-page {
   --haby-blue: #117BBF;
   --haby-mint: #6AACB0;
   --text: #0f172a;
@@ -9,13 +10,10 @@
   --bg: #f6fbff;
   --card: #ffffff;
   --danger: #c43535;
-}
 
-/* 画面全体 */
-.habit-form-page {
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
   padding: 18px 14px 28px;
-  background:#fff;
+  background: #fff;
 }
 
 .habit-form-container {
@@ -27,8 +25,12 @@
 
 /* 見出しカード */
 .habit-form-hero {
-  background: linear-gradient(135deg, rgba(17,123,191,0.18), rgba(106,172,176,0.14));
-  border: 1px solid rgba(17,123,191,0.18);
+  background: linear-gradient(
+    135deg,
+    rgba(17, 123, 191, 0.18),
+    rgba(106, 172, 176, 0.14)
+  );
+  border: 1px solid rgba(17, 123, 191, 0.18);
   border-radius: 18px;
   padding: 14px 14px 12px;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
@@ -60,7 +62,7 @@
 
 /* フォーム */
 .habit-form {
-  position: relative; 
+  position: relative;
   display: grid;
   gap: 14px;
 }
@@ -103,8 +105,8 @@
 
 .habit-form input[type="text"]:focus,
 .habit-form textarea:focus {
-  border-color: rgba(17,123,191,0.55);
-  box-shadow: 0 0 0 4px rgba(17,123,191,0.12);
+  border-color: rgba(17, 123, 191, 0.55);
+  box-shadow: 0 0 0 4px rgba(17, 123, 191, 0.12);
 }
 
 /* エラー表示 */
@@ -143,8 +145,8 @@
   margin-top: 4px;
 }
 
-/* habyボタン（一覧と揃える） */
-.haby-btn {
+/* habyボタン */
+.habit-form-page .haby-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -158,25 +160,25 @@
   cursor: pointer;
 }
 
-.haby-btn--primary {
+.habit-form-page .haby-btn--primary {
   color: #fff;
   background: var(--haby-blue);
-  box-shadow: 0 10px 20px rgba(17,123,191,0.22);
+  box-shadow: 0 10px 20px rgba(17, 123, 191, 0.22);
 }
 
-.haby-btn--ghost {
+.habit-form-page .haby-btn--ghost {
   color: var(--text);
   background: #fff;
   border-color: #d9e6f2;
 }
 
-.haby-btn--danger {
+.habit-form-page .haby-btn--danger {
   color: #fff;
   background: var(--danger);
-  box-shadow: 0 10px 20px rgba(239,68,68,0.18);
+  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.18);
 }
 
-/* 補助リンク（戻る等） */
+/* 補助リンク */
 .habit-form__back {
   font-size: 13px;
   color: var(--muted);

--- a/app/assets/stylesheets/pages/habit_show.css
+++ b/app/assets/stylesheets/pages/habit_show.css
@@ -1,6 +1,7 @@
 /* Habit Show  */
 
-:root {
+/* 画面全体 */
+.habit-show-page {
   --haby-blue: #117BBF;
   --haby-mint: #6AACB0;
   --text: #0f172a;
@@ -9,13 +10,10 @@
   --bg: #f6fbff;
   --card: #ffffff;
   --danger: #ef4444;
-}
 
-/* 画面全体 */
-.habit-show-page {
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
   padding: 18px 14px 28px;
-  background: #fff
+  background: #fff;
 }
 
 .habit-show-container {
@@ -121,7 +119,7 @@
 }
 
 /* ボタン */
-.haby-btn {
+.habit-show-page .haby-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -135,19 +133,19 @@
   cursor: pointer;
 }
 
-.haby-btn--primary {
+.habit-show-page .haby-btn--primary {
   color: #fff;
   background: var(--haby-blue);
   box-shadow: 0 10px 20px rgba(17,123,191,0.22);
 }
 
-.haby-btn--ghost {
+.habit-show-page .haby-btn--ghost {
   color: var(--text);
   background: #fff;
   border-color: #d9e6f2;
 }
 
-.haby-btn--danger {
+.habit-show-page .haby-btn--danger {
   color: #fff;
   background: var(--danger);
   box-shadow: 0 10px 20px rgba(239,68,68,0.18);

--- a/app/assets/stylesheets/pages/habits.css
+++ b/app/assets/stylesheets/pages/habits.css
@@ -1,6 +1,7 @@
 /* Habits Index */
 
-:root {
+/* ページ全体 */
+.habits-page {
   --haby-blue: #117BBF;
   --haby-mint: #6AACB0;
   --text: #0f172a;
@@ -8,13 +9,10 @@
   --line: #e6eef5;
   --bg: #f6fbff;
   --card: #ffffff;
-}
 
-/* ページ全体 */
-.habits-page {
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
   padding: 18px 14px 28px;
-  background:#fff
+  background: #fff;
 }
 
 .habits-container {
@@ -24,9 +22,13 @@
   gap: 14px;
 }
 
-/* タイトル帯（ページ見出し） */
+/* タイトル */
 .habits-hero {
-  background: linear-gradient(135deg, rgba(17,123,191,0.18), rgba(106,172,176,0.14));
+  background: linear-gradient(
+    135deg,
+    rgba(17,123,191,0.18),
+    rgba(106,172,176,0.14)
+  );
   border: 1px solid rgba(17,123,191,0.18);
   border-radius: 18px;
   padding: 14px 14px 12px;
@@ -71,7 +73,10 @@
   border-radius: 18px;
   padding: 14px;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
 }
 
 .habit-item:hover {
@@ -106,7 +111,7 @@
   text-underline-offset: 3px;
 }
 
-/* 右側のバッジ（例：カテゴリ/曜日/状態） */
+/* 右側のバッジ（カテゴリなど） */
 .habit-badge {
   flex: 0 0 auto;
   padding: 7px 10px;
@@ -114,7 +119,7 @@
   font-size: 12px;
   font-weight: 800;
   color: var(--haby-blue);
-  background: rgba(88, 157, 200, 0.1);
+  background: rgba(88, 157, 200, 0.10);
   border: 1px solid rgba(17,123,191,0.18);
 }
 
@@ -133,7 +138,8 @@
   gap: 15px;
 }
 
-.haby-btn {
+/* ボタン */
+.habits-page .haby-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -147,13 +153,13 @@
   cursor: pointer;
 }
 
-.haby-btn--primary {
+.habits-page .haby-btn--primary {
   color: #fff;
   background: var(--haby-blue);
   box-shadow: 0 10px 20px rgba(17,123,191,0.22);
 }
 
-.haby-btn--ghost {
+.habits-page .haby-btn--ghost {
   color: var(--text);
   background: #fff;
   border-color: var(--line);

--- a/app/assets/stylesheets/pages/home.css
+++ b/app/assets/stylesheets/pages/home.css
@@ -1,95 +1,136 @@
+/* Top Page */
 .top-wrapper {
-  max-width: 800px;
+  width: 100%;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 32px 16px;
   text-align: center;
+  box-sizing: border-box;
 }
 
+
+/* タイトル */
 .app-title {
-  font-size: 40px;
-  font-weight: bold;
+  margin: 0 0 12px;
+  font-weight: 900;
   color: #117BBF;
-  font-size: 60px;
+  letter-spacing: 0.2px;
+  font-size: clamp(36px, 7vw, 56px);
+}
+
+/* ヒーローボタン */
+.hero-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 18px;
 }
 
 .hero-buttons a {
-  display: inline-block;
-  margin: 10px;
-  padding: 20px 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 180px;
+  padding: 14px 18px;
   border-radius: 14px;
   text-decoration: none;
-  font-size: 20px;
+  font-size: 15px;
+  font-weight: 800;
 }
 
 /* CTA セクション */
 .cta {
+  width: min(92vw, 720px);
   text-align: center;
-  margin: 80px auto;
-  padding: 20px 10px;
+  margin: 44px auto 0;
+  padding: 22px 16px;
   background: linear-gradient(180deg, #e9f5ff, #f6fbff);
   border-radius: 20px;
   box-shadow:
-    0 6px 15px rgba(0, 0, 0, 0.06),
+    0 10px 25px rgba(15, 23, 42, 0.06),
     0 2px 4px rgba(255, 255, 255, 0.9) inset;
 }
 
 .cta h2 {
-  font-size: 26px;
-  font-weight: 700;
-  margin-bottom: 15px;
+  margin: 0 0 10px;
+  font-size: clamp(18px, 4.5vw, 24px);
+  font-weight: 900;
   color: #117BBF;
-  text-shadow: 0 1px 2px rgba(17, 123, 191, 0.15);
+  text-shadow: 0 1px 2px rgba(17, 123, 191, 0.12);
 }
 
 /* 機能紹介セクション */
 .features {
-  max-width: 800px;
-  margin: 60px auto;
-  padding: 0 20px;
+  width: min(92vw, 720px);
+  margin: 44px auto 0;
+  padding: 0 0;
   text-align: center;
 }
 
 .features h2 {
-  font-size: 28px;
-  font-weight: 700;
+  margin: 0 0 18px;
+  font-size: clamp(18px, 4.5vw, 26px);
+  font-weight: 900;
   color: #117BBF;
-  margin-bottom: 30px;
-  text-shadow: 0 1px 2px rgba(17, 123, 191, 0.15);
+  text-shadow: 0 1px 2px rgba(17, 123, 191, 0.12);
 }
 
 .feature-list {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: grid;
+  gap: 12px;
 }
 
 .feature-list li {
   background: #ffffff;
-  border-radius: 16px;
-  padding: 24px 28px;
-  margin-bottom: 20px;
+  border-radius: 18px;
+  padding: 18px 16px;
   box-shadow:
-    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 10px 25px rgba(15, 23, 42, 0.06),
     0 2px 3px rgba(255, 255, 255, 0.6) inset;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .feature-list li:hover {
-  transform: translateY(-4px);
+  transform: translateY(-3px);
   box-shadow:
-    0 8px 18px rgba(0,0,0,0.12),
+    0 14px 35px rgba(15, 23, 42, 0.10),
     0 3px 5px rgba(255,255,255,0.65) inset;
 }
 
 .feature-list h3 {
-  font-size: 22px;
-  font-weight: 600;
+  margin: 0 0 6px;
+  font-size: 18px;
+  font-weight: 900;
   color: #117BBF;
-  margin-bottom: 8px;
 }
 
 .feature-list p {
-  font-size: 16px;
+  margin: 0;
+  font-size: 14px;
   color: #555;
-  line-height: 1.6;
+  line-height: 1.7;
+}
+
+/* スマホ最適化 */
+@media (max-width: 480px) {
+  .top-wrapper {
+    padding: 24px 14px;
+  }
+
+  .hero-buttons a {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .cta {
+    margin-top: 32px;
+  }
+
+  .features {
+    margin-top: 32px;
+  }
 }

--- a/app/views/habit_logs/index.html.erb
+++ b/app/views/habit_logs/index.html.erb
@@ -1,14 +1,49 @@
-<h1><%= @date.strftime("%Y年%-m月%-d日") %> の記録</h1>
+<div class="habits-page">
+  <div class="habits-container">
 
-<% if @habit_logs.any? %>
-  <ul>
-    <% @habit_logs.each do |log| %>
-      <li>
-        <%= log.habit.name %>：
-        <%= log.is_taken? ? "実施" : "未実施" %>
-      </li>
+    <!-- 日付ヒーロー -->
+    <section class="habits-hero">
+      <h1 class="habits-hero__title">
+        <%= @date.strftime("%Y年%-m月%-d日") %> の記録
+      </h1>
+      <p class="habits-hero__subtitle">
+        この日の服用・習慣の実施状況
+      </p>
+    </section>
+
+    <% if @habit_logs.any? %>
+      <section class="habits-list">
+        <% @habit_logs.each do |log| %>
+          <article class="habit-item">
+            <div class="habit-item__head">
+              <h2 class="habit-item__name">
+                <%= log.habit.name %>
+              </h2>
+
+              <% if log.is_taken? %>
+                <span class="habit-badge">実施</span>
+              <% else %>
+                <span class="habit-badge">未実施</span>
+              <% end %>
+            </div>
+
+            <p class="habit-item__detail">
+              <%= log.is_taken? ? "この習慣は実施されました。" : "この習慣は未実施です。" %>
+            </p>
+          </article>
+        <% end %>
+      </section>
+
+    <% else %>
+      <div class="habits-empty">
+        <p class="habits-empty__title">
+          この日の記録はまだありません
+        </p>
+        <p class="habits-empty__text">
+          習慣を実施すると、ここに記録が表示されます。
+        </p>
+      </div>
     <% end %>
-  </ul>
-<% else %>
-  <p>この日の記録はまだありません。</p>
-<% end %>
+
+  </div>
+</div>

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -6,10 +6,6 @@
       <p class="habits-hero__subtitle">毎日ちょっとずつ、続けるためのメモ</p>
       <div class="habit-item__actions">
         <%= link_to "習慣を追加", new_habit_path, class: "haby-btn haby-btn--primary" %>
-        <%= link_to "今日の記録を見る",
-            habit_logs_path(date: Date.current),
-            class: "haby-btn haby-btn--secondary" %>
-
       </div>
 
     </section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,19 +7,6 @@
       つい忘れがちな“服薬・サプリ習慣”を、<br>
       やさしく続けられるようにデザインしました。
     </p>
-
-    <div class="hero-buttons">
-      <% if user_signed_in? %>
-        <span class="user-name">
-          <p><%= current_user.name.presence || "名称未設定" %>さん</p>
-        </span>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-primary" %>
-      <% else %>
-        <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary" %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-secondary" %>
-      <% end %>
-
-    </div>
   </section>
 
   <section class="features">

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -19,6 +19,13 @@
       <%= link_to "パスワードを変更", edit_account_password_path, class: "account-menu__link" %>
     </li>
     <li class="account-menu__item account-menu__item--danger">
+      <%= button_to "ログアウト",
+                    destroy_user_session_path,
+                    method: :delete,
+                    form: { data: { turbo_confirm: "ログアウトしますか？" } },
+                    class: "account-menu__link account-menu__link--danger" %>
+    </li>
+    <li class="account-menu__item account-menu__item--danger">
       <%= link_to "アカウントの削除", confirm_delete_account_path, class: "account-menu__link account-menu__link--danger" %>
     </li>
   </ul>

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -5,7 +5,7 @@
     <div class="bottom-nav__icon-wrapper">
       <%= image_tag "icons/checkbox.png", class: "bottom-nav__icon", alt: "" %>
     </div>
-    <span class="bottom-nav__label">今日の習慣</span>
+    <span class="bottom-nav__label">今日の習慣(準備中)</span>
   <% end %>
 
   <%= link_to calendar_path,


### PR DESCRIPTION
## 概要
habyアプリ全体のUIを調整し、操作しやすさとデザインの統一感を改善しました。

## 目的
- アカウントメニューの見た目を統一し、habyらしいUIに整えるため

## 作業内容
- ログアウトボタンをアカウントページ内メニューへ移動
- DeviseのログアウトをDELETE /users/sign_outで正しく処理するためbutton_toを使用
- アカウントメニュー内のテキストをすべて中央寄せに調整
- その他全体的にCSSファイル内の余白・見た目を調整

## 確認事項
- [ ] マイページからログアウトできること
- [ ] ログアウト時に Routing Error が発生しないこと
- [ ] アカウントメニューの各項目が中央寄せで表示されていること
- [ ] スマホ表示でもレイアウトが崩れていないこと
- [ ] 全体のデザインやレイアウトが崩れていないこと

## 関連issue
- close Issue #14 

## 備考
なし