### PR TITLE
feat: ハンバーガーメニューから認証案内ページへ遷移できるようにする

### DIFF
--- a/app/assets/stylesheets/pages/auth.css
+++ b/app/assets/stylesheets/pages/auth.css
@@ -1,0 +1,85 @@
+.auth-gate {
+  min-height: calc(100vh - 64px);
+  display: grid;
+  place-items: center;
+  padding: 28px 16px 44px;
+  background:
+    radial-gradient(1200px 700px at 30% 0%, rgba(17, 123, 191, 0.16), transparent 55%),
+    radial-gradient(900px 600px at 100% 30%, rgba(106, 172, 176, 0.14), transparent 55%),
+    linear-gradient(180deg, #ffffff 0%, #fbfdff 60%, #ffffff 100%);
+}
+
+.auth-gate__card {
+  width: min(520px, 100%);
+  padding: 22px 18px 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(17, 123, 191, 0.18);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+}
+
+.auth-gate__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 123, 191, 0.14), rgba(106, 172, 176, 0.12));
+  border: 1px solid rgba(17, 123, 191, 0.18);
+}
+
+.auth-gate__badge-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #117bbf;
+  box-shadow: 0 0 0 6px rgba(17, 123, 191, 0.14);
+}
+
+.auth-gate__badge-text {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 900;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.auth-gate__title {
+  margin: 14px 0 8px;
+  font-size: 30px;
+  font-weight: 950;
+  color: rgba(15, 23, 42, 0.95);
+}
+
+.auth-gate__lead {
+  margin: 0 0 14px;
+  font-size: 14px;
+  line-height: 1.8;
+  color: rgba(15, 23, 42, 0.62);
+}
+
+.auth-gate__actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.auth-gate__btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.auth-gate__note {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 12px;
+  color: rgba(15, 23, 42, 0.45);
+  letter-spacing: 0.08em;
+  font-weight: 800;
+}
+
+@media (min-width: 520px) {
+  .auth-gate__actions {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,11 @@ class PagesController < ApplicationController
     :confirm_delete_account, :destroy_account
   ]
 
+<<<<<<< Updated upstream
+  def calendar; end
+  def habits; end
+  def manage; end
+=======
   def calendar
     base_date =
       if params[:start_date].present?
@@ -39,9 +44,19 @@ class PagesController < ApplicationController
     end
   end
 
+  def auth
+    if user_signed_in?
+      redirect_to habits_path, notice: "すでにログインしています"
+    end
+  end
 
 
-  def manage; end
+  def todays_habits
+  end
+
+  def manage
+  end
+>>>>>>> Stashed changes
 
   # マイページ
   def account

--- a/app/views/pages/auth.html.erb
+++ b/app/views/pages/auth.html.erb
@@ -1,0 +1,23 @@
+<div class="auth-gate">
+  <div class="auth-gate__card">
+    <div class="auth-gate__badge">
+      <span class="auth-gate__badge-dot"></span>
+      <span class="auth-gate__badge-text">WELCOME TO HABY</span>
+    </div>
+
+    <h1 class="auth-gate__title">はじめましょう</h1>
+    <p class="auth-gate__lead">
+      habyは「今日やること」を小さく続けるためのアプリです。<br>
+      まずはログイン、または新規登録をしてください。
+    </p>
+
+    <div class="auth-gate__actions">
+      <%= link_to "ログイン", new_user_session_path, class: "btn btn--primary" %>
+      <%= link_to "新規登録", new_user_registration_path, class: "btn" %>
+    </div>
+
+    <p class="auth-gate__note">
+      ※ 登録は1分ほどで完了します
+    </p>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,11 +26,20 @@
 
   <!-- ハンバーガーで開くメニュー -->
   <nav class="app-header__nav" id="global-nav">
-    <ul class="app-header__nav-list">
-      <li><a href="#" class="app-header__nav-link">habyとは</a></li>
-      <li><a href="#" class="app-header__nav-link">使い方</a></li>
-      <li><a href="#" class="app-header__nav-link">新規登録/ログイン</a></li>
-      <li><a href="#" class="app-header__nav-link">その他</a></li>
-    </ul>
-  </nav>
+  <ul class="app-header__nav-list">
+    <li>
+      <%= link_to "habyとは", home_index_path, class: "app-header__nav-link menu__link" %>
+    </li>
+    <li>
+      <%= link_to "使い方", todays_habits_path, class: "app-header__nav-link menu__link" %>
+    </li>
+    <li>
+      <%= link_to "ログイン / 新規登録", auth_path, class: "app-header__nav-link menu__link" %>
+    </li>
+    <li>
+      <%= link_to "その他", todays_habits_path, class: "app-header__nav-link menu__link" %>
+    </li>
+  </ul>
+</nav>
+
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :habits, only: %i[new create index show edit update destroy]
-  resources :habits do
-    resource :today_log, only: [ :update ], controller: "habit_logs"
-  end
-  resources :habit_logs, only: %i[index]
-
   root "home#index"
   get "home/index"
 
@@ -14,7 +8,14 @@ Rails.application.routes.draw do
   get "contact",  to: "static_pages#contact"
 
   get "calendar", to: "pages#calendar"
+<<<<<<< Updated upstream
+  get "habits", to: "pages#habits"
   get "manage", to: "pages#manage"
+=======
+  get "todays_habits", to: "pages#todays_habits"
+  get "auth", to: "pages#auth"
+
+>>>>>>> Stashed changes
 
   # マイページ
   get "account", to: "pages#account", as: :account


### PR DESCRIPTION
## 概要
ハンバーガーメニュー内のリンク構造を修正し、未ログインユーザーが「ログイン / 新規登録」へ迷わず遷移できるようにしました。
その他実装準備中のページ作成を行い、リンクを作成しユーザーが閲覧できるようにしました。

## 目的
- ハンバーガーメニューの内容からユーザーが簡単にリンクへ移動できるようにするため
- ログイン/新規登録への遷移を分かりやすくする

## 作業内容
- ハンバーガーメニューのリンクを `link_to` のみに統一し、`<a>` タグの入れ子を解消
- 「ログイン / 新規登録」メニューから `auth_path` へ遷移するリンクを追加
- その他ハンバーガーメニューのリンク内容を作成

## 確認事項
- [ ] ハンバーガーメニューが開閉できること
- [ ] 「habyとは」リンクから該当ページへ遷移できること
- [ ] 「ログイン / 新規登録」リンクから `/auth` に遷移できること
- [ ] その他のページからリンクが遷移されること￥
- [ ] 画面遷移時にルーティングエラーが発生しないこと

## 関連issue
- なし（UI改善）

## 備考
なし
