### PR TITLE
feat: ハンバーガーメニューからリンクへ遷移できるようにする

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,4 +16,6 @@
  *= require pages/habits
  *= require pages/habit_form
  *= require pages/habit_show
+ *= require pages/auth
+ *= require pages/today
  */

--- a/app/assets/stylesheets/pages/auth.css
+++ b/app/assets/stylesheets/pages/auth.css
@@ -1,0 +1,85 @@
+.auth-gate {
+  min-height: calc(100vh - 64px);
+  display: grid;
+  place-items: center;
+  padding: 28px 16px 44px;
+  background:
+    radial-gradient(1200px 700px at 30% 0%, rgba(17, 123, 191, 0.16), transparent 55%),
+    radial-gradient(900px 600px at 100% 30%, rgba(106, 172, 176, 0.14), transparent 55%),
+    linear-gradient(180deg, #ffffff 0%, #fbfdff 60%, #ffffff 100%);
+}
+
+.auth-gate__card {
+  width: min(520px, 100%);
+  padding: 22px 18px 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(17, 123, 191, 0.18);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+}
+
+.auth-gate__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 123, 191, 0.14), rgba(106, 172, 176, 0.12));
+  border: 1px solid rgba(17, 123, 191, 0.18);
+}
+
+.auth-gate__badge-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #117bbf;
+  box-shadow: 0 0 0 6px rgba(17, 123, 191, 0.14);
+}
+
+.auth-gate__badge-text {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 900;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.auth-gate__title {
+  margin: 14px 0 8px;
+  font-size: 30px;
+  font-weight: 950;
+  color: rgba(15, 23, 42, 0.95);
+}
+
+.auth-gate__lead {
+  margin: 0 0 14px;
+  font-size: 14px;
+  line-height: 1.8;
+  color: rgba(15, 23, 42, 0.62);
+}
+
+.auth-gate__actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.auth-gate__btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.auth-gate__note {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 12px;
+  color: rgba(15, 23, 42, 0.45);
+  letter-spacing: 0.08em;
+  font-weight: 800;
+}
+
+@media (min-width: 520px) {
+  .auth-gate__actions {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/app/assets/stylesheets/pages/today.css
+++ b/app/assets/stylesheets/pages/today.css
@@ -1,0 +1,204 @@
+/* Today  */
+
+:root {
+  --haby-primary: #117bbf;
+  --haby-secondary: #6aacb0;
+  --haby-text: #0f172a;
+  --haby-muted: rgba(15, 23, 42, 0.62);
+  --haby-line: rgba(17, 123, 191, 0.18);
+}
+
+.comingsoon {
+  position: relative;
+  min-height: calc(100vh - 64px);
+  display: grid;
+  place-items: center;
+  padding: 28px 16px 44px;
+  background: radial-gradient(1200px 700px at 30% 0%, rgba(17, 123, 191, 0.18), transparent 55%),
+              radial-gradient(900px 600px at 100% 30%, rgba(106, 172, 176, 0.18), transparent 55%),
+              linear-gradient(180deg, #ffffff 0%, #fbfdff 60%, #ffffff 100%);
+  overflow: hidden;
+}
+
+.comingsoon__bg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* --- blobs --- */
+.comingsoon__blob {
+  position: absolute;
+  width: 420px;
+  height: 420px;
+  border-radius: 999px;
+  filter: blur(10px);
+  opacity: 0.55;
+  transform: translate3d(0,0,0);
+  mix-blend-mode: multiply;
+}
+
+/* --- card --- */
+.comingsoon__card {
+  position: relative;
+  width: min(560px, 100%);
+  padding: 22px 18px 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--haby-line);
+  box-shadow:
+    0 18px 42px rgba(15, 23, 42, 0.08),
+    0 6px 18px rgba(17, 123, 191, 0.08);
+}
+
+.comingsoon__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(17, 123, 191, 0.16), rgba(106, 172, 176, 0.14));
+  border: 1px solid rgba(17, 123, 191, 0.22);
+}
+
+.comingsoon__badge-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--haby-primary);
+  box-shadow: 0 0 0 6px rgba(17, 123, 191, 0.16);
+  animation: habyPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes habyPulse {
+  0%, 100% { transform: scale(1); box-shadow: 0 0 0 6px rgba(17, 123, 191, 0.14); }
+  50%      { transform: scale(1.08); box-shadow: 0 0 0 10px rgba(17, 123, 191, 0.10); }
+}
+
+.comingsoon__badge-text {
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  font-weight: 900;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.comingsoon__title {
+  margin: 14px 0 10px;
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  color: var(--haby-text);
+  font-weight: 950;
+}
+
+.comingsoon__lead {
+  margin: 0 0 14px;
+  color: var(--haby-muted);
+  font-size: 14px;
+  line-height: 1.8;
+}
+
+.comingsoon__meter {
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(14, 74, 213, 0.06);
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.comingsoon__meter-bar {
+  height: 100%;
+  width: 60%;
+  border-radius: 999px;
+  background: rgba(17, 123, 191, 0.85);
+  animation: habyMeter 2.2s ease-in-out infinite;
+}
+
+@keyframes habyMeter {
+  0%   { transform: translateX(-35%); }
+  50%  { transform: translateX(15%); }
+  100% { transform: translateX(-35%); }
+}
+
+.comingsoon__chips {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.comingsoon__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 900;
+  color: rgba(15, 23, 42, 0.7);
+  background: rgba(17, 123, 191, 0.08);
+  border: 1px solid rgba(17, 123, 191, 0.16);
+}
+
+.comingsoon__actions {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.comingsoon__btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  text-decoration: none;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  transition: transform .12s ease, box-shadow .12s ease, filter .12s ease;
+}
+
+.comingsoon__btn:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.comingsoon__btn--primary {
+  color: #fff;
+  background: linear-gradient(90deg, rgba(17, 123, 191, 1), rgba(106, 172, 176, 1));
+  box-shadow: 0 10px 22px rgba(17, 123, 191, 0.18);
+}
+
+.comingsoon__btn--primary:hover {
+  filter: brightness(1.02);
+  box-shadow: 0 14px 28px rgba(17, 123, 191, 0.22);
+}
+
+.comingsoon__btn--ghost {
+  color: rgba(15, 23, 42, 0.8);
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(17, 123, 191, 0.18);
+}
+
+.comingsoon__btn--ghost:hover {
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+}
+
+.comingsoon__note {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 12px;
+  color: rgba(15, 23, 42, 0.45);
+  letter-spacing: 0.14em;
+  font-weight: 800;
+}
+
+.comingsoon__br { display: none; }
+
+@media (min-width: 520px) {
+  .comingsoon__actions { grid-template-columns: 1fr 1fr; }
+  .comingsoon__title { font-size: 32px; }
+  .comingsoon__br { display: inline; }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -43,6 +43,12 @@ class PagesController < ApplicationController
 
   def manage; end
 
+  def auth
+    if user_signed_in?
+      redirect_to habits_path, notice: "すでにログインしています"
+    end
+  end
+
   # マイページ
   def account
   end

--- a/app/views/pages/auth.html.erb
+++ b/app/views/pages/auth.html.erb
@@ -1,0 +1,23 @@
+<div class="auth-gate">
+  <div class="auth-gate__card">
+    <div class="auth-gate__badge">
+      <span class="auth-gate__badge-dot"></span>
+      <span class="auth-gate__badge-text">WELCOME TO HABY</span>
+    </div>
+
+    <h1 class="auth-gate__title">はじめましょう</h1>
+    <p class="auth-gate__lead">
+      habyは「今日やること」を小さく続けるためのアプリです。<br>
+      まずはログイン、または新規登録をしてください。
+    </p>
+
+    <div class="auth-gate__actions">
+      <%= link_to "ログイン", new_user_session_path, class: "btn btn--primary" %>
+      <%= link_to "新規登録", new_user_registration_path, class: "btn" %>
+    </div>
+
+    <p class="auth-gate__note">
+      ※ 登録は1分ほどで完了します
+    </p>
+  </div>
+</div>

--- a/app/views/pages/todays_habits.html.erb
+++ b/app/views/pages/todays_habits.html.erb
@@ -1,0 +1,25 @@
+<div class="comingsoon">
+  <div class="comingsoon__card">
+    <div class="comingsoon__badge">
+      <span class="comingsoon__badge-dot"></span>
+      <span class="comingsoon__badge-text">NOW BUILDING</span>
+    </div>
+
+    <h1 class="comingsoon__title">
+      実装準備中です
+    </h1>
+
+    <p class="comingsoon__lead">
+      只今実装準備中。完成するまでしばらくお待ちください。
+    </p>
+
+    <div class="comingsoon__meter" aria-hidden="true">
+      <div class="comingsoon__meter-bar"></div>
+    </div>
+
+    <div class="comingsoon__actions">
+      <%= link_to "習慣一覧に戻る", habits_path, class: "btn btn--primary" %>
+      <%= link_to "カレンダーを見る", calendar_path, class: "btn comingsoon__btn--ghost" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -1,6 +1,6 @@
 <!-- app/views/shared/_bottom_nav.html.erb -->
 <nav class="bottom-nav">
-  <%= link_to home_index_path,
+  <%= link_to todays_habits_path,
               class: "bottom-nav__item #{'bottom-nav__item--active' if current_page?(home_index_path)}" do %>
     <div class="bottom-nav__icon-wrapper">
       <%= image_tag "icons/checkbox.png", class: "bottom-nav__icon", alt: "" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -27,10 +27,10 @@
   <!-- ハンバーガーで開くメニュー -->
   <nav class="app-header__nav" id="global-nav">
     <ul class="app-header__nav-list">
-      <li><a href="#" class="app-header__nav-link">habyとは</a></li>
-      <li><a href="#" class="app-header__nav-link">使い方</a></li>
-      <li><a href="#" class="app-header__nav-link">新規登録/ログイン</a></li>
-      <li><a href="#" class="app-header__nav-link">その他</a></li>
+      <li><%= link_to "habyとは", home_index_path, class: "menu__link" %></li>
+      <li><%= link_to "使い方", todays_habits_path, class: "menu__link" %></li>
+      <li><%= link_to "ログイン / 新規登録", auth_path, class: "menu__link" %></li>
+      <li><%= link_to "その他", todays_habits_path, class: "menu__link" %></li>
     </ul>
   </nav>
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
 
   get "calendar", to: "pages#calendar"
   get "manage", to: "pages#manage"
+  get "auth", to: "pages#auth"
+  get "todays_habits", to: "pages#todays_habits"
 
   # マイページ
   get "account", to: "pages#account", as: :account


### PR DESCRIPTION
## 概要
ハンバーガーメニュー内のリンク構造を修正し、未ログインユーザーが「ログイン / 新規登録」へ迷わず遷移できるようにしました。
その他実装準備中のページ作成を行い、リンクを作成しユーザーが閲覧できるようにしました。

## 目的
- ハンバーガーメニューの内容からユーザーが簡単にリンクへ移動できるようにするため
- ログイン/新規登録への遷移を分かりやすくする

## 作業内容
- ハンバーガーメニューのリンクを `link_to` のみに統一し、`<a>` タグの入れ子を解消
- 「ログイン / 新規登録」メニューから `auth_path` へ遷移するリンクを追加
- その他ハンバーガーメニューのリンク内容を作成

## 確認事項
- [ ] ハンバーガーメニューが開閉できること
- [ ] 「habyとは」リンクから該当ページへ遷移できること
- [ ] 「ログイン / 新規登録」リンクから `/auth` に遷移できること
- [ ] その他のページからリンクが遷移されること￥
- [ ] 画面遷移時にルーティングエラーが発生しないこと

## 関連issue
- なし（UI改善）

## 備考
なし
