### PR TITLE
fix: カレンダーの達成判定が一部実施でも「全部達成」表示にになる不具合を修正

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,35 +9,40 @@ class PagesController < ApplicationController
   ]
 
   def calendar
-    base_date =
-      if params[:start_date].present?
-        Date.parse(params[:start_date])
-      else
-        Date.current
-      end
-
-    from = base_date.beginning_of_month
-    to   = base_date.end_of_month
-
-    logs = current_user.habit_logs.where(log_date: from..to)
-
-    logs_by_date = logs.group_by(&:log_date)
-
-    @day_class = {}
-    logs_by_date.each do |date, day_logs|
-      total = day_logs.size
-      taken = day_logs.count { |l| l.is_taken }
-
-      @day_class[date] =
-        if taken == total
-          "cal-day--all"
-        elsif taken == 0
-          "cal-day--none"
-        else
-          "cal-day--partial"
-        end
+  base_date =
+    if params[:start_date].present?
+      Date.parse(params[:start_date])
+    else
+      Date.current
     end
+
+  from = base_date.beginning_of_month
+  to   = base_date.end_of_month
+
+  logs = current_user.habit_logs.where(log_date: from..to)
+  logs_by_date = logs.group_by(&:log_date)
+
+  total_habits = current_user.habits.count
+
+  @day_class = {}
+
+  (from..to).each do |date|
+    day_logs = logs_by_date[date] || []
+    taken = day_logs.count { |l| l.is_taken }
+
+    @day_class[date] =
+      if total_habits == 0
+        "cal-day--none"
+      elsif taken == 0
+        "cal-day--none"
+      elsif taken < total_habits
+        "cal-day--partial"
+      else
+        "cal-day--all"
+      end
   end
+end
+
 
 
 


### PR DESCRIPTION
## 概要
カレンダー上で、習慣を一部しか実施していない日にもかかわらず
「全部達成（complete）」と表示されてしまう不具合を修正しました。

## 目的
日ごとの習慣達成状況を正しく反映し、
ユーザーが実際の実施状況と一致した形でカレンダーを確認できるようにするため。

## 作業内容
- 日別の達成判定ロジックを修正
- 「その日にログが存在する数」ではなく、
  「ユーザーが持つ習慣の総数」を基準に達成状態を判定するよう変更
- 以下の3状態を正しく判定するように修正
  - 全部達成
  - 一部達成
  - 達成なし

## 確認事項
- [ ] 習慣を一部のみ実施した日は「一部達成」と表示される
- [ ] 全ての習慣を実施した日は「全部達成」と表示される
- [ ] 何も実施していない日は「達成なし」と表示される
- [ ] カレンダーの表示が月遷移・今日ボタン操作で崩れない

## 関連issue
- #34 

## 備考
- なし
