### PR TITLE
すべて実施している日がcomplete表示されないバグの修正

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,39 +9,51 @@ class PagesController < ApplicationController
   ]
 
   def calendar
-  base_date =
-    if params[:start_date].present?
-      Date.parse(params[:start_date])
-    else
-      Date.current
-    end
-
-  from = base_date.beginning_of_month
-  to   = base_date.end_of_month
-
-  logs = current_user.habit_logs.where(log_date: from..to)
-  logs_by_date = logs.group_by(&:log_date)
-
-  total_habits = current_user.habits.count
-
-  @day_class = {}
-
-  (from..to).each do |date|
-    day_logs = logs_by_date[date] || []
-    taken = day_logs.count { |l| l.is_taken }
-
-    @day_class[date] =
-      if total_habits == 0
-        "cal-day--none"
-      elsif taken == 0
-        "cal-day--none"
-      elsif taken < total_habits
-        "cal-day--partial"
+    base_date =
+      if params[:start_date].present?
+        Date.parse(params[:start_date])
       else
-        "cal-day--all"
+        Date.current
       end
+
+    from = base_date.beginning_of_month
+    to   = base_date.end_of_month
+
+    # log_date が date/datetime どちらでも安全な範囲指定
+    logs = current_user.habit_logs.where(log_date: from.beginning_of_day..to.end_of_day)
+    logs_by_date = logs.group_by { |l| l.log_date.to_date }
+
+    @day_class = {}
+
+    (from..to).each do |date|
+      # ✅「その日までに存在していた習慣」を対象にする（過去の整合性が取れる）
+      total =
+        current_user.habits
+          .where("created_at <= ?", date.end_of_day)
+          .count
+
+      day_logs = logs_by_date[date] || []
+      taken =
+        day_logs
+          .select(&:is_taken)
+          .map(&:habit_id)
+          .uniq
+          .count
+
+      @day_class[date] =
+        if total == 0
+          "cal-day--none"
+        elsif taken == 0
+          "cal-day--none"
+        elsif taken < total
+          "cal-day--partial"
+        else
+          "cal-day--all"
+        end
+    end
   end
-end
+
+
 
 
 

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -7,4 +7,8 @@ class Habit < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 100 }
   validates :current_streak, :longest_streak, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :active_on, ->(date) {
+    where("created_at <= ?", date.end_of_day)
+  }
 end


### PR DESCRIPTION
## 概要
カレンダー画面において、過去の習慣をすべて実施している日がcomplete表示されない問題を修正しました。

## 目的
- 習慣を後から追加した場合でも、過去の日付の complete/partial判定が崩れないようにするため
- カレンダーの実施表示を実際の状況に合うような表示にするため

## 作業内容
- カレンダーのcomplete判定ロジックを修正
  - 「現在の習慣総数」ではなく「その日までに存在していた習慣数」を対象に判定するよう変更
- 将来的な曜日指定機能追加を見据え、対象習慣判定を拡張しやすい構造に整理

## 確認事項
- [ ] 習慣を後から追加しても、過去の全部達成日がcomplete表示されること
- [ ] 一部のみ実施した日はpartial表示になること
- [ ] 習慣が0件の日はnone表示になること
- [ ] カレンダー月送り時の表示に不整合がないこと

## 関連issue
- close #34

## 備考
- なし
