### PR TITLE
ログイン機能の一部削除

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,20 +14,20 @@
         <%= f.password_field :password, autocomplete: "current-password" %>
       </div>
 
-      <% if devise_mapping.rememberable? %>
-        <div class="field field-remember">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me, "ログイン状態を保持する" %>
-        </div>
-      <% end %>
+      <%# if devise_mapping.rememberable? %>
+        <%# <div class="field field-remember"> %>
+          <%# <%= f.check_box :remember_me %>
+          <%# <%= f.label :remember_me, "ログイン状態を保持する" %>
+        <%# </div> %>
+      <%# <% end %>
 
       <div class="actions">
         <%= f.submit "ログイン", class: "auth-button" %>
       </div>
     <% end %>
     
-    <div class="auth-links">
+    <%# <div class="auth-links">
       <%= render "devise/shared/links" %>
-    </div>
+    <%# </div> %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
ログイン画面において、現在はまだ未実装の「ログイン機能を保持」・「パスワードを忘れた方はこちら」の表示を削除し、修正しました。

## 目的
- 本リリース時に上記機能を実装予定のため、MVPリリース時には未実装のままで置いておくため。

## 作業内容
- 「ログイン機能を保持」表示を削除
- 「パスワードを忘れた方はこちら」の表示を削除

## 確認事項
- [ ] 今までと同様にログイン実施に問題がないこと
- [ ] レイアウト崩れがないこと

## 関連issue
- なし

## 備考
- なし