### PR TITLE
パスワードリセット機能の実装

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> さん</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの変更がリクエストされました。以下のリンクからパスワードを変更できます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to "パスワードを変更する", edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このリクエストに心当たりがない場合は、このメールを無視してください。</p>
+<p>上記リンクにアクセスしてパスワードを変更するまで、現在のパスワードは変更されません。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,31 @@
-<h2>Change your password</h2>
+<div class="auth-wrapper">
+  <div class="auth-card">
+    <h2 class="auth-title">新しいパスワードの設定</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="field">
+        <%= f.label :password, "新しいパスワード" %><br />
+        <% if @minimum_password_length %>
+          <em>（<%= @minimum_password_length %>文字以上）</em><br />
+        <% end %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password_confirmation, "新しいパスワード（確認用）" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "パスワードを変更する", class: "auth-button" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <div class="auth-links">
+      <%= link_to "ログインに戻る", new_session_path(resource_name) %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,22 @@
-<h2>Forgot your password?</h2>
+<div class="auth-wrapper">
+  <div class="auth-card">
+    <h2 class="auth-title">パスワードをお忘れですか？</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="field">
+        <%= f.label :email, "メールアドレス" %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "送信する", class: "auth-button" %>
+      </div>
+    <% end %>
+
+    <div class="auth-links">
+      <%= link_to "ログインに戻る", new_session_path(resource_name) %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -27,6 +27,10 @@
     <% end %>
     
     <div class="auth-links">
+      <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: "auth-links__forgot" %>
+    </div>
+
+    <div class="auth-links">
       <p class="auth-links__text">アカウントをお持ちでない方は</p>
       <%= link_to "新規登録はこちら", new_user_registration_path, class: "auth-links__signup" %>
     </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,6 +109,11 @@ Rails.application.configure do
     config.action_mailer.raise_delivery_errors = false
   end
 
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "yourhaby.com"),
+    protocol: "https"
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch("MAIL_FROM", "no-reply@yourhaby.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,3 +7,34 @@ ja:
         name: "お名前"
         email: "メールアドレス"
         message: "お問い合わせ内容"
+  devise:
+    passwords:
+      no_token: "リセットトークンがありません。パスワードリセットメールのリンクからアクセスしてください。"
+      send_instructions: "パスワードリセットの手順をメールで送信しました。"
+      send_paranoid_instructions: "メールアドレスが登録されている場合、パスワードリセットの手順をメールで送信しました。"
+      updated: "パスワードが変更されました。ログインしました。"
+      updated_not_active: "パスワードが変更されました。"
+    failure:
+      invalid: "メールアドレスまたはパスワードが正しくありません。"
+      unauthenticated: "ログインしてください。"
+      not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+      already_signed_out: "既にログアウトしています。"
+    registrations:
+      signed_up: "登録が完了しました。"
+      destroyed: "アカウントが削除されました。"
+      updated: "アカウント情報を更新しました。"
+    mailer:
+      reset_password_instructions:
+        subject: "パスワードリセットのご案内"
+  errors:
+    messages:
+      expired: "の有効期限が切れています。新しくリクエストしてください。"
+      not_found: "は見つかりませんでした。"
+      already_confirmed: "は既に確認済みです。ログインしてください。"
+      not_locked: "はロックされていません。"
+      not_saved:
+        one: "1件のエラーが発生したため、保存できませんでした："
+        other: "%{count}件のエラーが発生したため、保存できませんでした："


### PR DESCRIPTION
## 概要         
パスワードリセット機能の実装をしました。

## 目的
ユーザーがパスワードを忘れた場合に、メール経由でパスワードを再設定できるようにし、ログイン不能に
よるユーザー離脱を防止するため。

## 作業内容                                                                                        
- ログインページに「パスワードを忘れた方はこちら」リンクを追加                                  
- パスワードリセット関連ビューを日本語化し、既存の認証ページとスタイルを統一
- 本番環境のメール設定を修正

## 確認事項                                                  
- ログインページから「パスワードを忘れた方はこちら」リンクでリセット申請フォームに遷移できる
- リセットメールが日本語で送信され、メール内リンクからパスワード変更フォームに遷移できる        
- 新しいパスワードを設定後、ログイン状態に遷移し日本語のフラッシュメッセージが表示される

## 関連issue
- close #114                                                                                    

## 備考
-