### PR TITLE
Googleログイン認証機能の実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       ADMIN_EMAIL: "admin@example.com"
       MAIL_FROM: "no-reply@yourhaby.com"
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/haby_test
+      GOOGLE_CLIENT_ID: "test"
+      GOOGLE_CLIENT_SECRET: "test"
 
     services:
       postgres:

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "devise"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 gem "devise-i18n"
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,8 +132,16 @@ GEM
     drb (2.2.3)
     erb (6.0.0)
     erubi (1.13.1)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -147,6 +155,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.17.1)
+    jwt (3.1.2)
+      base64
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -176,6 +186,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.2)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -202,6 +216,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -234,6 +272,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.4)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -328,6 +370,9 @@ GEM
       websocket (~> 1.0)
     simple_calendar (3.1.0)
       rails (>= 6.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -350,7 +395,9 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
+    uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -392,6 +439,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   letter_opener_web
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   pry-byebug
   pry-rails
@@ -450,13 +499,17 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.0) sha256=2730893f9d8c9733f16cab315a4e4b71c1afa9cabc1a1e7ad1403feba8f52579
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   i18n (1.14.7) sha256=ceba573f8138ff2c0915427f1fc5bdf4aa3ab8ae88c8ce255eb3ecf0a11a5d0f
   io-console (0.8.1) sha256=1e15440a6b2f67b6ea496df7c474ed62c860ad11237f29b3bd187f054b925fcb
   irb (1.15.3) sha256=4349edff1efa7ff7bfd34cb9df74a133a588ba88c2718098b3b4468b81184aaa
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.17.1) sha256=e0e4824541336a44915436f53e7ea74c687314fb8f88080fa1456f6a34ead92e
+  jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
@@ -471,6 +524,8 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.26.2) sha256=f021118a6185b9ba9f5af71f2ba103ad770c75afde9f2ab8da512677c550cde3
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.5.12) sha256=cb8cd05bd353fcc19b6cbc530a9cb06b577a969ea10b7ddb0f37787f74be4444
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -484,6 +539,11 @@ CHECKSUMS
   nokogiri (1.18.10-x86_64-darwin) sha256=536e74bed6db2b5076769cab5e5f5af0cd1dccbbd75f1b3e1fa69d1f5c2d79e2
   nokogiri (1.18.10-x86_64-linux-gnu) sha256=ff5ba26ba2dbce5c04b9ea200777fd225061d7a3930548806f31db907e500f72
   nokogiri (1.18.10-x86_64-linux-musl) sha256=0651fccf8c2ebbc2475c8b1dfd7ccac3a0a6d09f8a41b72db8c21808cb483385
+  oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
+  omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
+  omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
+  omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
+  omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
@@ -505,6 +565,7 @@ CHECKSUMS
   puma (7.1.0) sha256=e45c10cb124f224d448c98db653a75499794edbecadc440ad616cf50f2fd49dd
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.4) sha256=5d74b6f75082a643f43c1e76b419c40f0e5527fcfee1e669ac1e6b73c0ccb6f6
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
@@ -531,6 +592,7 @@ CHECKSUMS
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.39.0) sha256=984a1e63d39472eaf286bac3c6f1822fa7eea6eed9c07a66ce7b3bc5417ba826
   simple_calendar (3.1.0) sha256=56764606c3804c70e6facb47b6571ec79d7ce941e77b6bd3678869c1350a720c
+  snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
@@ -542,7 +604,9 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.1.0) sha256=4997d2d5df1ed4252f4830a9b6e86f932e2013fbff2182a9ce9ccabda4f325a5
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737

--- a/app/assets/stylesheets/pages/account.css
+++ b/app/assets/stylesheets/pages/account.css
@@ -31,6 +31,18 @@
   color: #117bbf;
 }
 
+.account-page__sns-info {
+  text-align: center;
+  font-size: 13px;
+  color: #6b7280;
+  background: #f0f7fc;
+  padding: 8px 16px;
+  border-radius: 999px;
+  margin-bottom: 8px;
+  display: inline-block;
+  width: 100%;
+}
+
 /* メニューリスト */
 .account-menu {
   margin-top: 40px;

--- a/app/assets/stylesheets/pages/devise.css
+++ b/app/assets/stylesheets/pages/devise.css
@@ -166,6 +166,61 @@
   color: #b91c1c;
 }
 
+/* SNSログイン セパレーター */
+.auth-divider {
+  display: flex;
+  align-items: center;
+  margin: 24px 0 20px;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.auth-divider__text {
+  padding: 0 12px;
+  font-size: 13px;
+  color: #9ca3af;
+}
+
+/* SNSボタン */
+.auth-sns-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.auth-sns-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 11px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 999px;
+  border: 1px solid #d0d7de;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.auth-sns-button--google {
+  background: #fff;
+  color: #3c4043;
+}
+
+.auth-sns-button--google:hover {
+  background: #f8f9fa;
+}
+
+.auth-sns-icon {
+  flex-shrink: 0;
+}
+
 /* スマホ微調整 */
 @media (max-width: 480px) {
   .auth-wrapper {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -109,21 +109,33 @@ class PagesController < ApplicationController
   end
 
   def update_email
-    # Devise の update_with_password を利用（current_password が必要）
-    if current_user.update_with_password(email_params)
-      # メールやパスワードを変えたら再ログイン状態を維持
-      bypass_sign_in(current_user)
-      redirect_to account_path, notice: "メールアドレスを変更しました。"
+    if current_user.provider.present?
+      # SNSユーザーはパスワード不要で更新
+      if current_user.update(params.require(:user).permit(:email))
+        bypass_sign_in(current_user)
+        redirect_to account_path, notice: "メールアドレスを変更しました。"
+      else
+        render :edit_email, status: :unprocessable_entity
+      end
     else
-      render :edit_email, status: :unprocessable_entity
+      # Devise の update_with_password を利用（current_password が必要）
+      if current_user.update_with_password(email_params)
+        bypass_sign_in(current_user)
+        redirect_to account_path, notice: "メールアドレスを変更しました。"
+      else
+        render :edit_email, status: :unprocessable_entity
+      end
     end
   end
 
   # パスワード変更
   def edit_password
+    redirect_to account_path, alert: "SNSログインのためパスワード変更はできません。" if current_user.provider.present?
   end
 
   def update_password
+    return redirect_to account_path, alert: "SNSログインのためパスワード変更はできません。" if current_user.provider.present?
+
     if current_user.update_with_password(password_params)
       bypass_sign_in(current_user)
       redirect_to account_path, notice: "パスワードを変更しました。"

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,27 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+    handle_omniauth("Google")
+  end
+
+  def failure
+    redirect_to new_user_session_path, alert: "認証に失敗しました。もう一度お試しください。"
+  end
+
+  private
+
+  def handle_omniauth(provider_name)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      flash[:notice] = "#{provider_name}アカウントでログインしました。"
+      sign_in_and_redirect @user, event: :authentication
+    else
+      flash[:alert] = "#{provider_name}アカウントでの認証に失敗しました。"
+      redirect_to new_user_session_path
+    end
+  rescue StandardError => e
+    Rails.logger.error "OmniAuth error (#{provider_name}): #{e.message}"
+    flash[:alert] = "認証処理中にエラーが発生しました。もう一度お試しください。"
+    redirect_to new_user_session_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,39 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   validates :name, presence: true, length: { maximum: 50 }
 
   has_many :habits, dependent: :destroy
   has_many :habit_logs, dependent: :destroy
+
+  def password_required?
+    super && provider.blank?
+  end
+
+  def self.from_omniauth(auth)
+    # provider + uid で既存SNSユーザーを検索
+    user = find_by(provider: auth.provider, uid: auth.uid)
+    return user if user
+
+    # メールアドレスで既存通常ユーザーを検索し、SNS情報を紐付け
+    if auth.info.email.present?
+      user = find_by(email: auth.info.email)
+      if user
+        user.update!(provider: auth.provider, uid: auth.uid)
+        return user
+      end
+    end
+
+    # 新規ユーザー作成
+    create!(
+      provider: auth.provider,
+      uid: auth.uid,
+      email: auth.info.email,
+      name: auth.info.name || "ユーザー",
+      password: Devise.friendly_token[0, 20]
+    )
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,6 +31,9 @@
         <%= f.submit "登録する", class: "auth-button", data: { loading_text: "登録中..." } %>
       </div>
     <% end %>
+
+    <%= render "devise/shared/sns_buttons" %>
+
     <div class="auth-links">
       <%= render "devise/shared/links" %>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -25,7 +25,9 @@
         <%= f.submit "ログイン", class: "auth-button", data: { loading_text: "ログイン中..." } %>
       </div>
     <% end %>
-    
+
+    <%= render "devise/shared/sns_buttons" %>
+
     <div class="auth-links">
       <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: "auth-links__forgot" %>
     </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -18,8 +18,3 @@
   <%= link_to "解除の手順を受け取れていません", new_unlock_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "#{OmniAuth::Utils.camelize(provider)}でログインする", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
-  <% end %>
-<% end %>

--- a/app/views/devise/shared/_sns_buttons.html.erb
+++ b/app/views/devise/shared/_sns_buttons.html.erb
@@ -1,0 +1,18 @@
+<% if devise_mapping.omniauthable? %>
+  <div class="auth-divider">
+    <span class="auth-divider__text">または</span>
+  </div>
+  <div class="auth-sns-buttons">
+    <%= button_to user_google_oauth2_omniauth_authorize_path,
+        method: :post, data: { turbo: false },
+        class: "auth-sns-button auth-sns-button--google" do %>
+      <svg class="auth-sns-icon" viewBox="0 0 24 24" width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+      </svg>
+      Googleでログイン
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -8,6 +8,12 @@
     のアカウント設定
   </p>
 
+  <% if current_user.provider.present? %>
+    <p class="account-page__sns-info">
+      Googleアカウントで連携中
+    </p>
+  <% end %>
+
   <ul class="account-menu">
     <li class="account-menu__item">
       <%= link_to "名前を変更", edit_account_name_path, class: "account-menu__link" %>
@@ -15,9 +21,11 @@
     <li class="account-menu__item">
       <%= link_to "メールアドレスを変更", edit_account_email_path, class: "account-menu__link" %>
     </li>
-    <li class="account-menu__item">
-      <%= link_to "パスワードを変更", edit_account_password_path, class: "account-menu__link" %>
-    </li>
+    <% unless current_user.provider.present? %>
+      <li class="account-menu__item">
+        <%= link_to "パスワードを変更", edit_account_password_path, class: "account-menu__link" %>
+      </li>
+    <% end %>
     <li class="account-menu__item account-menu__item--danger">
       <%= button_to "ログアウト",
                     destroy_user_session_path,

--- a/app/views/pages/edit_email.html.erb
+++ b/app/views/pages/edit_email.html.erb
@@ -13,15 +13,17 @@
                           class: "account-form__input" %>
       </div>
 
-      <div class="account-form__field">
-        <%= f.label :current_password, "現在のパスワード", class: "account-form__label" %><br>
-        <%= f.password_field :current_password,
-                             autocomplete: "current-password",
-                             class: "account-form__input" %>
-        <p class="account-form__help-text">
-          本人確認のため、現在のパスワードを入力してください。
-        </p>
-      </div>
+      <% unless current_user.provider.present? %>
+        <div class="account-form__field">
+          <%= f.label :current_password, "現在のパスワード", class: "account-form__label" %><br>
+          <%= f.password_field :current_password,
+                               autocomplete: "current-password",
+                               class: "account-form__input" %>
+          <p class="account-form__help-text">
+            本人確認のため、現在のパスワードを入力してください。
+          </p>
+        </div>
+      <% end %>
 
       <div class="account-form__actions">
         <%= f.submit "メールアドレスを更新する", class: "account-form__submit", data: { loading_text: "更新中..." } %>

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,8 @@ services:
       - .:/haby
       - bundle_data:/usr/local/bundle:cached
       - node_modules:/haby/node_modules
+    env_file:
+      - .env
     environment:
       TZ: Asia/Tokyo
       ADMIN_EMAIL: "supica0746@example.com"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -276,6 +276,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :google_oauth2,
+                  ENV.fetch("GOOGLE_CLIENT_ID", ""),
+                  ENV.fetch("GOOGLE_CLIENT_SECRET", ""),
+                  scope: "email,profile"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,9 @@ ja:
       signed_up: "登録が完了しました。"
       destroyed: "アカウントが削除されました。"
       updated: "アカウント情報を更新しました。"
+    omniauth_callbacks:
+      success: "%{kind}アカウントでログインしました。"
+      failure: "%{kind}アカウントでの認証に失敗しました。(%{reason})"
     mailer:
       reset_password_instructions:
         subject: "パスワードリセットのご案内"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get "contacts/new"
-  devise_for :users
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
   resources :habits, only: %i[new create index show edit update destroy]
   resources :habits do
     resource :today_log, only: [ :update ], controller: "habit_logs"

--- a/db/migrate/20260412071457_add_omniauth_to_users.rb
+++ b/db/migrate/20260412071457_add_omniauth_to_users.rb
@@ -1,0 +1,7 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_index :users, [ :provider, :uid ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_03_121909) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_12_071457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,7 +62,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_03_121909) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -14,3 +14,10 @@ two:
   name: テストユーザー2
   encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
 
+google_user:
+  email: google@example.com
+  name: Googleユーザー
+  encrypted_password: <%= Devise::Encryptor.digest(User, Devise.friendly_token[0, 20]) %>
+  provider: google_oauth2
+  uid: "google-uid-123"
+

--- a/test/integration/omniauth_test.rb
+++ b/test/integration/omniauth_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class OmniauthTest < ActionDispatch::IntegrationTest
+  def mock_google_auth(email: "integration@gmail.com", name: "テスト太郎", uid: "integration-test-uid")
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: uid,
+      info: { email: email, name: name }
+    )
+  end
+
+  setup do
+    mock_google_auth
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+  end
+
+  teardown do
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    Rails.application.env_config["omniauth.auth"] = nil
+  end
+
+  test "google callback creates user and signs in" do
+    assert_difference "User.count", 1 do
+      get "/users/auth/google_oauth2/callback"
+    end
+    assert_response :redirect
+    follow_redirect!
+    assert flash[:notice].present?
+  end
+
+  test "google callback with existing user signs in without creating new user" do
+    get "/users/auth/google_oauth2/callback"
+    delete destroy_user_session_path
+
+    assert_no_difference "User.count" do
+      get "/users/auth/google_oauth2/callback"
+    end
+    assert_response :redirect
+  end
+
+  test "failed authentication redirects to login page" do
+    Rails.application.env_config["omniauth.auth"] = nil
+    OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+    # OmniAuth failure はミドルウェアで処理されるため、
+    # コントローラーの failure メソッドを直接テスト
+    get user_google_oauth2_omniauth_callback_path
+    assert_redirected_to new_user_session_path
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,61 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "from_omniauth creates new user from google auth" do
+    auth = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "new-google-uid",
+      info: { email: "newuser@gmail.com", name: "新規ユーザー" }
+    )
+
+    assert_difference "User.count", 1 do
+      user = User.from_omniauth(auth)
+      assert user.persisted?
+      assert_equal "google_oauth2", user.provider
+      assert_equal "new-google-uid", user.uid
+      assert_equal "newuser@gmail.com", user.email
+      assert_equal "新規ユーザー", user.name
+    end
+  end
+
+  test "from_omniauth finds existing user by provider and uid" do
+    google_user = users(:google_user)
+    auth = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "google-uid-123",
+      info: { email: "google@example.com", name: "Googleユーザー" }
+    )
+
+    assert_no_difference "User.count" do
+      user = User.from_omniauth(auth)
+      assert_equal google_user.id, user.id
+    end
+  end
+
+  test "from_omniauth links to existing email user" do
+    existing = users(:one)
+    auth = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "new-uid-999",
+      info: { email: existing.email, name: existing.name }
+    )
+
+    assert_no_difference "User.count" do
+      user = User.from_omniauth(auth)
+      assert_equal existing.id, user.id
+      assert_equal "google_oauth2", user.reload.provider
+      assert_equal "new-uid-999", user.uid
+    end
+  end
+
+  test "sns user does not require password" do
+    user = User.new(
+      name: "SNSユーザー",
+      email: "sns-new@example.com",
+      provider: "google_oauth2",
+      uid: "test-uid-456",
+      password: Devise.friendly_token[0, 20]
+    )
+    assert user.valid?
+  end
 end

--- a/test/system/omniauth_test.rb
+++ b/test/system/omniauth_test.rb
@@ -1,0 +1,40 @@
+require "application_system_test_case"
+
+class OmniauthSystemTest < ApplicationSystemTestCase
+  test "login page shows Google login button" do
+    visit new_user_session_path
+    assert_selector ".auth-sns-button--google"
+    assert_text "Googleでログイン"
+  end
+
+  test "registration page shows Google login button" do
+    visit new_user_registration_path
+    assert_selector ".auth-sns-button--google"
+    assert_text "Googleでログイン"
+  end
+
+  test "sns user account page hides password change link" do
+    google_user = users(:google_user)
+    sign_in google_user
+    visit account_path
+    assert_no_text "パスワードを変更"
+    assert_text "Googleアカウントで連携中"
+  end
+
+  test "normal user account page shows password change link" do
+    user = users(:one)
+    sign_in user
+    visit account_path
+    assert_text "パスワードを変更"
+    assert_no_text "Googleアカウントで連携中"
+  end
+
+  private
+
+  def sign_in(user)
+    visit new_user_session_path
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: "password"
+    click_button "ログイン"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,9 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+OmniAuth.config.test_mode = true
+OmniAuth.config.silence_get_warning = true
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,135 @@
 # yarn lockfile v1
 
 
+"@esbuild/aix-ppc64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz#116edcd62c639ed8ab551e57b38251bb28384de4"
+  integrity sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==
+
+"@esbuild/android-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz#31c00d864c80f6de1900a11de8a506dbfbb27349"
+  integrity sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==
+
+"@esbuild/android-arm@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.1.tgz#d2b73ab0ba894923a1d1378fd4b15cc20985f436"
+  integrity sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==
+
+"@esbuild/android-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.1.tgz#d9f74d8278191317250cfe0c15a13f410540b122"
+  integrity sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==
+
 "@esbuild/darwin-arm64@0.27.1":
   version "0.27.1"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz"
   integrity sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==
+
+"@esbuild/darwin-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz#64e37400795f780a76c858a118ff19681a64b4e0"
+  integrity sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==
+
+"@esbuild/freebsd-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz#6572f2f235933eee906e070dfaae54488ee60acd"
+  integrity sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==
+
+"@esbuild/freebsd-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz#83105dba9cf6ac4f44336799446d7f75c8c3a1e1"
+  integrity sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==
+
+"@esbuild/linux-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz#035ff647d4498bdf16eb2d82801f73b366477dfa"
+  integrity sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==
+
+"@esbuild/linux-arm@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz#3516c74d2afbe305582dbb546d60f7978a8ece7f"
+  integrity sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==
+
+"@esbuild/linux-ia32@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz#788db5db8ecd3d75dd41c42de0fe8f1fd967a4a7"
+  integrity sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==
+
+"@esbuild/linux-loong64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz#8211f08b146916a6302ec2b8f87ec0cc4b62c49e"
+  integrity sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==
+
+"@esbuild/linux-mips64el@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz#cc58586ea83b3f171e727a624e7883a1c3eb4c04"
+  integrity sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==
+
+"@esbuild/linux-ppc64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz#632477bbd98175cf8e53a7c9952d17fb2d6d4115"
+  integrity sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==
+
+"@esbuild/linux-riscv64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz#35435a82435a8a750edf433b83ac0d10239ac3fe"
+  integrity sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==
+
+"@esbuild/linux-s390x@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz#172edd7086438edacd86c0e2ea25ac9dbb62aac5"
+  integrity sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==
+
+"@esbuild/linux-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz#09c771de9e2d8169d5969adf298ae21581f08c7f"
+  integrity sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==
+
+"@esbuild/netbsd-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz#475ac0ce7edf109a358b1669f67759de4bcbb7c4"
+  integrity sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==
+
+"@esbuild/netbsd-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz#3c31603d592477dc43b63df1ae100000f7fb59d7"
+  integrity sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==
+
+"@esbuild/openbsd-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz#482067c847665b10d66431e936d4bc5fa8025abf"
+  integrity sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==
+
+"@esbuild/openbsd-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz#687a188c2b184e5b671c5f74a6cd6247c0718c52"
+  integrity sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==
+
+"@esbuild/openharmony-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz#9929ee7fa8c1db2f33ef4d86198018dac9c1744f"
+  integrity sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==
+
+"@esbuild/sunos-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz#94071a146f313e7394c6424af07b2b564f1f994d"
+  integrity sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==
+
+"@esbuild/win32-arm64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz#869fde72a3576fdf48824085d05493fceebe395d"
+  integrity sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==
+
+"@esbuild/win32-ia32@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz#31d7585893ed7b54483d0b8d87a4bfeba0ecfff5"
+  integrity sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==
+
+"@esbuild/win32-x64@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz#5efe5a112938b1180e98c76685ff9185cfa4f16e"
+  integrity sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==
 
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"


### PR DESCRIPTION
## 概要                                                                                         
Googleアカウントを使用したOAuth認証（SNSログイン）機能を実装しました。                          

## 目的                                                                                         
新規登録・ログインのハードルを下げ、UXを向上させるため。

## 作業内容                             
- OmniAuth（omniauth-google-oauth2, omniauth-rails_csrf_protection）を導入し、DeviseにGoogleログイン機能を追加                      
- usersテーブルにproviderとuidカラムを追加し、既存ユーザーとのメールアドレスによる自動紐付けを実装 
- ログイン・新規登録画面にGoogleロゴ付きのSNSログインボタンを追加                              
- SNSユーザー向けのマイページ対応
- 認証失敗時のエラー対応とフラッシュメッセージを実装                                    
- テストの追加

## 確認事項                                                                                     
- [ ] ログイン・新規登録画面に「Googleでログイン」ボタンが表示される                            
- [ ] Googleアカウントでログイン/新規登録ができる                                               
- [ ] 同じメールアドレスの既存ユーザーがGoogleログインした場合、アカウントが正しく紐付く        
- [ ] SNSユーザーのマイページで「パスワードを変更」が非表示になる                               
- [ ] SNSユーザーのメールアドレス変更時にパスワード入力が不要になる                             
- [ ] 認証キャンセル時にエラーメッセージが表示されログイン画面に戻る                            
- [ ] 既存のテストが全て通過する
- [ ] Rubocopの違反がない

## 関連issue
- close #115
## 備考                                                                                         
- 