### PR TITLE
レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/base/reset.css
+++ b/app/assets/stylesheets/base/reset.css
@@ -1,3 +1,18 @@
 *, *::before, *::after {
   box-sizing: border-box;
 }
+
+/* iOS Safariで入力時の自動ズームを防止（font-size 16px未満で発生） */
+@media (max-width: 768px) {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="tel"],
+  input[type="url"],
+  input[type="search"],
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}

--- a/app/assets/stylesheets/components/header.css
+++ b/app/assets/stylesheets/components/header.css
@@ -191,3 +191,28 @@
 .menu__link:hover::after {
   width: calc(100% - 40px);
 }
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .app-header__inner {
+    padding: 4px 12px;
+  }
+
+  .app-header__logo {
+    height: 34px;
+  }
+
+  .app-header__nav {
+    width: 78%;
+  }
+
+  .app-header__nav-list {
+    margin: 56px 10px 10px;
+    padding: 10px 6px 14px;
+  }
+
+  .menu__link {
+    padding: 12px 14px;
+    font-size: 15px;
+  }
+}

--- a/app/assets/stylesheets/pages/habit_form.css
+++ b/app/assets/stylesheets/pages/habit_form.css
@@ -286,5 +286,68 @@
   box-shadow: 0 4px 12px rgba(239, 68, 68, 0.25);
 }
 
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .habit-form-page {
+    padding: 14px 10px 24px;
+  }
+
+  .habit-form-hero {
+    padding: 12px 12px 10px;
+    border-radius: 14px;
+  }
+
+  .habit-form-hero__title {
+    font-size: 16px;
+  }
+
+  .habit-form-card {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .habit-form input[type="text"],
+  .habit-form textarea {
+    padding: 10px;
+    border-radius: 12px;
+  }
+
+  .schedule-days-presets {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .schedule-preset-btn {
+    padding: 5px 10px;
+    font-size: 11px;
+  }
+
+  .schedule-day-toggle__label {
+    width: 36px;
+    height: 36px;
+    font-size: 12px;
+  }
+
+  .schedule-days-buttons {
+    gap: 4px;
+  }
+
+  .habit-form__actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .habit-form__actions .haby-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .habit-form-page .haby-btn {
+    padding: 8px 10px;
+    font-size: 12px;
+    border-radius: 12px;
+  }
+}
+
 
 

--- a/app/assets/stylesheets/pages/habit_show.css
+++ b/app/assets/stylesheets/pages/habit_show.css
@@ -156,3 +156,46 @@
   gap: 10px;
   flex-wrap: wrap;
 }
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .habit-show-page {
+    padding: 14px 10px 24px;
+  }
+
+  .habit-show-hero {
+    padding: 12px 12px 10px;
+    border-radius: 14px;
+  }
+
+  .habit-show-hero__titleRow {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .habit-show-hero__title {
+    font-size: 16px;
+  }
+
+  .habit-show-card {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .habit-show-card::before {
+    width: 120px;
+    height: 70px;
+    inset: -30px auto auto -40px;
+  }
+
+  .habit-show-actions {
+    gap: 6px;
+  }
+
+  .habit-show-page .haby-btn {
+    padding: 7px 8px;
+    font-size: 11px;
+    border-radius: 12px;
+    gap: 4px;
+  }
+}

--- a/app/assets/stylesheets/pages/habits.css
+++ b/app/assets/stylesheets/pages/habits.css
@@ -188,3 +188,49 @@
   margin: 6px 0 0;
   font-size: 13px;
 }
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .habits-page {
+    padding: 14px 10px 24px;
+  }
+
+  .habits-hero {
+    padding: 12px 12px 10px;
+    border-radius: 14px;
+  }
+
+  .habits-hero__title {
+    font-size: 16px;
+  }
+
+  .habit-item {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .habit-item__head {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .habit-item__name {
+    font-size: 14px;
+  }
+
+  .habit-badge,
+  .habit-badge-danger {
+    padding: 5px 8px;
+    font-size: 11px;
+  }
+
+  .habit-item__actions {
+    gap: 10px;
+  }
+
+  .habits-page .haby-btn {
+    padding: 8px 10px;
+    font-size: 12px;
+    border-radius: 12px;
+  }
+}

--- a/app/assets/stylesheets/pages/today.css
+++ b/app/assets/stylesheets/pages/today.css
@@ -463,3 +463,53 @@
   color: var(--haby-text);
   border-color: rgba(17, 123, 191, 0.18);
 }
+
+/* ── Responsive: Today's Habits ── */
+@media (max-width: 480px) {
+  .todays-habits-page {
+    padding: 14px 10px 24px;
+  }
+
+  .todays-habits-hero {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .todays-habits-hero__title {
+    font-size: 18px;
+  }
+
+  .todays-habits-section {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .todays-habit-item {
+    padding: 10px 12px;
+    border-radius: 12px;
+    gap: 8px;
+  }
+
+  .todays-habit-item__name {
+    font-size: 13px;
+  }
+
+  .todays-habit-btn {
+    padding: 6px 12px;
+    font-size: 12px;
+  }
+
+  .todays-habits-complete-message {
+    padding: 18px;
+    border-radius: 14px;
+  }
+
+  .todays-habits-empty {
+    padding: 24px 12px;
+  }
+
+  .todays-habits-empty__actions .haby-btn {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## 概要                                                                      
主要ページにモバイル端末向けメディアクエリを追加し 、スマホ・PCで崩れずに利用できるようレスポンシブ対応を実施しました。

## 目的
利用端末の違いでユーザーが使いづらくならないようにするため。また、iPhoneSEなどの小型スマホでのUI崩れ・操作性の問題を解消するため。

## 作業内容
- 習慣フォーム: 曜日選択ボタンの縮小、ボタンの折り返し対応
- 習慣詳細: タイトル行の折り返し対応、装飾要素の縮小、調整 
- 習慣一覧: カード内の名前・バッジの折り返し対応
- 今日の習慣: セクション・アイテムのpadding/border-radius縮小
- ヘッダー: 幅の拡大、ロゴ・メニューリンクの縮小
- iOS Safari自動ズーム防止: モバイルでの入力欄font-sizeを16pxに統一

## 確認事項                                                                  
- iPhoneSEで主要ページ（習慣一覧/詳細/フォーム/今日の習慣）が崩れないこと
- PC（1440px）で既存のレイアウトに影響がないこと
- スマホでフォーム入力時にiOS Safariの自動ズームが発生しないこと

## 関連issue
- close #127 

## 備考
- 既存のレスポンシブ対応済みページには変更なし