### PR TITLE
認証画面フォーム入力時の画面自動拡大を修正

### DIFF
--- a/app/assets/stylesheets/pages/devise.css
+++ b/app/assets/stylesheets/pages/devise.css
@@ -51,7 +51,7 @@
 .auth-card input[type="text"] {
   width: 100%;
   padding: 10px 12px;
-  font-size: 14px;
+  font-size: 16px;
   border-radius: 10px;
   border: 1px solid #d0d7de;
   box-sizing: border-box;


### PR DESCRIPTION
## 概要                                                                      
ログイン・新規登録画面のフォーム入力時に、iOSで画面が自動拡大され入力終了 
後も元に戻らない問題を修正しました。

## 目的                                                                      
iOSでは、フォントサイズが16px未満の<input>要素にフォーカスすると画
面が自動ズームされる仕様があり、ログイン・新規登録フォームで入力後も拡大が
解除されず画面全体が見づらくなっていたため。

## 作業内容                                                                  
- app/assets/stylesheets/pages/devise.cssの.auth-card                 
内のCSSを修正
- ログイン画面・新規登録画面・パスワードリセット画面すべてに共通のスタイル
のため、1箇所の修正で全画面に反映           

## 確認事項                                                                  
- iOSのSafariでログイン画面のフォーム入力時に画面が自動拡大されないこと   
- iOSのSafariで新規登録画面のフォーム入力時に画面が自動拡大されないこと
- iOSのSafariでパスワードリセット画面のフォーム入力時に画面が自動拡大され 
ないこと                                                                  
- PC・Android端末でフォームの表示が崩れていないこと
 
## 関連issue                                                                 
- close #134 

## 備考                                                                      
-