### PR TITLE
全体のレイアウト・デザイン統一・修正

### DIFF
--- a/app/assets/stylesheets/base/variables.css
+++ b/app/assets/stylesheets/base/variables.css
@@ -48,4 +48,33 @@
   /* Brand variations (便利) */
   --brand-weak: #e8f3fb;
   --brand-hover: #0e6aa5;
+  --brand-secondary: #6AACB0;
+
+  /* Card */
+  --card-bg: #ffffff;
+  --card-radius: var(--radius-lg);
+  --card-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  --card-border: rgba(17, 123, 191, 0.12);
+
+  /* Form input */
+  --input-bg: #f8fcff;
+  --input-border: #d0e3f3;
+  --input-radius: var(--radius-sm);
+  --input-focus-border: var(--brand);
+  --input-focus-shadow: 0 0 0 2px rgba(17, 123, 191, 0.18);
+
+  /* Page title */
+  --page-title-size: 20px;
+  --page-title-weight: 700;
+  --page-title-color: var(--brand);
+
+  /* Page container */
+  --page-max-width: 720px;
+  --page-padding: 18px 14px 28px;
+
+  /* Button (app内共通) */
+  --btn-radius: var(--radius-md);
+  --btn-font-size: 13px;
+  --btn-font-weight: 700;
+  --btn-padding: 10px 14px;
 }

--- a/app/assets/stylesheets/components/buttons.css
+++ b/app/assets/stylesheets/components/buttons.css
@@ -222,3 +222,59 @@
   position: relative;
   overflow: visible;
 }
+
+/* ── アプリ内共通ボタン ── */
+.haby-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: var(--btn-padding);
+  border-radius: var(--btn-radius);
+  font-weight: var(--btn-font-weight);
+  font-size: var(--btn-font-size);
+  text-decoration: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.12s ease;
+}
+
+.haby-btn--primary {
+  color: #fff;
+  background: var(--brand);
+  box-shadow: 0 10px 20px rgba(17, 123, 191, 0.22);
+}
+
+.haby-btn--primary:hover {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+.haby-btn--ghost {
+  color: var(--text);
+  background: #fff;
+  border-color: var(--card-border);
+}
+
+.haby-btn--ghost:hover {
+  background: var(--brand-weak);
+}
+
+.haby-btn--danger {
+  color: #fff;
+  background: var(--danger);
+  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.18);
+}
+
+.haby-btn--danger:hover {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 480px) {
+  .haby-btn {
+    padding: 8px 10px;
+    font-size: 12px;
+    border-radius: var(--radius-sm);
+  }
+}

--- a/app/assets/stylesheets/components/haby_calendar.css
+++ b/app/assets/stylesheets/components/haby_calendar.css
@@ -1,10 +1,4 @@
 :root{
-  --haby-primary: #117BBF;
-  --haby-primary-soft: rgba(17,123,191,0.10);
-  --haby-border: rgba(0,0,0,0.08);
-  --haby-text: rgba(0,0,0,0.86);
-  --haby-muted: rgba(0,0,0,0.45);
-
   /* 実施状況色分け */
   --cal-all: rgb(238, 178, 156);
   --cal-all-border: rgb(244, 146, 111);
@@ -41,7 +35,7 @@
   padding-left: 12px;
   font-size:20px;
   font-weight:900;
-  color:var(--haby-text);
+  color:var(--text);
   letter-spacing:.2px;
   white-space: nowrap;
 }
@@ -55,7 +49,7 @@
   width: 6px;
   height: 18px;
   border-radius: 999px;
-  background: var(--haby-primary);
+  background: var(--brand);
   opacity: 0.9;
 }
 
@@ -71,7 +65,7 @@
   border:1px solid rgba(17,123,191,0.18);
   background: rgba(17,123,191,0.04);
   text-decoration:none;
-  color:var(--haby-text);
+  color:var(--text);
   font-weight:800;
   font-size:13px;
   box-shadow:
@@ -109,7 +103,7 @@
   gap:6px;
   font-size:12px;
   font-weight:800;
-  color: var(--haby-muted);
+  color: var(--text-muted);
   padding:6px 10px;
   border-radius: 999px;
   border:1px solid rgba(0,0,0,0.06);
@@ -142,7 +136,7 @@
   text-align:center;
   font-size:13px;
   font-weight:800;
-  color:var(--haby-muted);
+  color:var(--text-muted);
   padding:6px 0;
   border-radius: 12px;
 }
@@ -174,7 +168,7 @@
 .haby-cal__date{
   font-size:13px;
   font-weight:900;
-  color:var(--haby-text);
+  color:var(--text);
   line-height: 1.1;
 }
 
@@ -182,7 +176,7 @@
   margin-top:6px;
   font-size:12px;
   line-height:1.25;
-  color: var(--haby-text);
+  color: var(--text);
   overflow:hidden;
 }
 

--- a/app/assets/stylesheets/pages/account.css
+++ b/app/assets/stylesheets/pages/account.css
@@ -3,19 +3,16 @@
   width: min(92vw, 640px);
   margin: 24px auto;
   padding: 24px 16px;
-  background: #ffffff;
-  border-radius: 20px;
-
-  box-shadow:
-    0 12px 30px rgba(0, 0, 0, 0.06),
-    0 2px 4px rgba(255, 255, 255, 0.7) inset;
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
 }
 
 
 .account-page__title {
-  font-size: 24px;
-  font-weight: 700;
-  color: #117bbf;
+  font-size: var(--page-title-size);
+  font-weight: var(--page-title-weight);
+  color: var(--page-title-color);
   text-align: center;
   margin-bottom: 12px;
 }
@@ -28,7 +25,7 @@
 }
 
 .account-page__user-name {
-  color: #117bbf;
+  color: var(--brand);
 }
 
 .account-page__sns-info {
@@ -62,9 +59,9 @@
   text-align: center;
 
   padding: 14px 16px;
-  border-radius: 14px;
+  border-radius: var(--radius-md);
   background: #f5fbff;
-  color: #117bbf;
+  color: var(--brand);
   font-size: 15px;
   font-weight: 600;
   text-decoration: none;

--- a/app/assets/stylesheets/pages/account_forms.css
+++ b/app/assets/stylesheets/pages/account_forms.css
@@ -6,21 +6,19 @@
 }
 
 .account-form-page__title {
-  font-size: 22px;
-  font-weight: 700;
-  color: #117bbf;
+  font-size: var(--page-title-size);
+  font-weight: var(--page-title-weight);
+  color: var(--page-title-color);
   text-align: center;
   margin-bottom: 16px;
 }
 
 /* カード部分 */
 .account-form-card {
-  background: #ffffff;
-  border-radius: 20px;
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
   padding: 24px 20px 28px;
-  box-shadow:
-    0 12px 30px rgba(0, 0, 0, 0.06),
-    0 2px 4px rgba(255, 255, 255, 0.7) inset;
+  box-shadow: var(--card-shadow);
 }
 
 /* フィールド */
@@ -39,11 +37,11 @@
 .account-form__input {
   width: 100%;
   padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid #d0e3f3;
+  border-radius: var(--input-radius);
+  border: 1px solid var(--input-border);
   font-size: 14px;
   outline: none;
-  background: #f8fcff;
+  background: var(--input-bg);
   min-height: 44px;
   transition:
     border-color 0.2s ease,
@@ -52,9 +50,9 @@
 }
 
 .account-form__input:focus {
-  border-color: #117bbf;
+  border-color: var(--input-focus-border);
   background: #ffffff;
-  box-shadow: 0 0 0 2px rgba(17, 123, 191, 0.18);
+  box-shadow: var(--input-focus-shadow);
 }
 
 /* 説明テキスト */
@@ -74,11 +72,11 @@
   display: inline-block;
   min-width: 220px;
   padding: 10px 18px;
-  border-radius: 999px;
+  border-radius: var(--btn-radius);
   border: none;
   font-size: 14px;
   font-weight: 600;
-  background: linear-gradient(135deg, #117bbf, #6aacb0);
+  background: linear-gradient(135deg, var(--brand), var(--brand-secondary));
   color: #fff;
   cursor: pointer;
   box-shadow: 0 8px 18px rgba(17, 123, 191, 0.3);
@@ -107,7 +105,7 @@
 
 .account-form__back-link {
   font-size: 13px;
-  color: #117bbf;
+  color: var(--brand);
   text-decoration: none;
 }
 

--- a/app/assets/stylesheets/pages/devise.css
+++ b/app/assets/stylesheets/pages/devise.css
@@ -17,21 +17,19 @@
 /* カード */
 .auth-card {
   width: min(92vw, 520px);
-  background: #fff;
+  background: var(--card-bg);
   padding: 28px 20px;
-  border-radius: 16px;
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.08),
-    0 0 0 1px rgba(17, 123, 191, 0.08);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
 }
 
 /* タイトル */
 .auth-title {
-  font-size: 22px;
-  font-weight: 700;
+  font-size: var(--page-title-size);
+  font-weight: var(--page-title-weight);
   text-align: center;
   margin-bottom: 20px;
-  color: #117BBF;
+  color: var(--page-title-color);
 }
 
 /* フォームのパーツ */
@@ -52,15 +50,17 @@
   width: 100%;
   padding: 10px 12px;
   font-size: 16px;
-  border-radius: 10px;
-  border: 1px solid #d0d7de;
+  border-radius: var(--input-radius);
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
   box-sizing: border-box;
 }
 
 .auth-card input:focus {
   outline: none;
-  border-color: #117BBF;
-  box-shadow: 0 0 0 2px rgba(17, 123, 191, 0.15);
+  border-color: var(--input-focus-border);
+  background: #fff;
+  box-shadow: var(--input-focus-shadow);
 }
 
 /* ボタン */
@@ -68,10 +68,10 @@
   width: 100%;
   border: none;
   padding: 12px 12px;
-  border-radius: 999px;
+  border-radius: var(--btn-radius);
   font-size: 15px;
   font-weight: 600;
-  background: #117BBF;
+  background: var(--brand);
   color: #fff;
   cursor: pointer;
 }
@@ -86,7 +86,7 @@
 
 /* links */
 .auth-card a {
-  color: #117BBF;
+  color: var(--brand);
   font-size: 13px;
 }
 
@@ -122,10 +122,10 @@
   padding: 10px 24px;
   font-size: 14px;
   font-weight: 600;
-  color: #117BBF;
-  background: #f0f7fc;
+  color: var(--brand);
+  background: var(--brand-weak);
   border: 1px solid rgba(17, 123, 191, 0.2);
-  border-radius: 999px;
+  border-radius: var(--btn-radius);
   text-decoration: none;
   transition: background 0.2s ease, border-color 0.2s ease;
 }
@@ -144,7 +144,7 @@
 .error_explanation {
   margin-bottom: 16px;
   padding: 12px 14px;
-  border-radius: 10px;
+  border-radius: var(--input-radius);
   background: #fef2f2;
   border: 1px solid #fecaca;
 }
@@ -202,8 +202,8 @@
   padding: 11px 16px;
   font-size: 14px;
   font-weight: 600;
-  border-radius: 999px;
-  border: 1px solid #d0d7de;
+  border-radius: var(--btn-radius);
+  border: 1px solid var(--input-border);
   cursor: pointer;
   transition: background 0.2s;
 }

--- a/app/assets/stylesheets/pages/habit_form.css
+++ b/app/assets/stylesheets/pages/habit_form.css
@@ -2,22 +2,13 @@
 
 /* 画面全体 */
 .habit-form-page {
-  --haby-blue: #117BBF;
-  --haby-mint: #6AACB0;
-  --text: #0f172a;
-  --muted: #64748b;
-  --line: #e6eef5;
-  --bg: #f6fbff;
-  --card: #ffffff;
-  --danger: #c43535;
-
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
-  padding: 18px 14px 28px;
-  background: #fff;
+  padding: var(--page-padding);
+  background: var(--bg);
 }
 
 .habit-form-container {
-  max-width: 720px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   display: grid;
   gap: 14px;
@@ -31,33 +22,33 @@
     rgba(106, 172, 176, 0.14)
   );
   border: 1px solid rgba(17, 123, 191, 0.18);
-  border-radius: 18px;
+  border-radius: var(--card-radius);
   padding: 14px 14px 12px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .habit-form-hero__title {
   margin: 0;
-  font-size: 18px;
-  font-weight: 900;
+  font-size: var(--page-title-size);
+  font-weight: 800;
   color: var(--text);
 }
 
 .habit-form-hero__subtitle {
   margin: 6px 0 0;
   font-size: 13px;
-  color: var(--muted);
+  color: var(--text-muted);
 }
 
 /* フォームカード */
 .habit-form-card {
   position: relative;
   overflow: hidden;
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
   padding: 14px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 /* フォーム */
@@ -74,7 +65,7 @@
 
 .habit-form__label {
   font-size: 13px;
-  font-weight: 900;
+  font-weight: 800;
   color: var(--text);
   letter-spacing: 0.2px;
 }
@@ -82,18 +73,18 @@
 .habit-form__hint {
   margin: 0;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--text-muted);
 }
 
 /* 入力 */
 .habit-form input[type="text"],
 .habit-form textarea {
   width: 100%;
-  padding: 12px 12px;
-  border-radius: 14px;
-  border: 1px solid #d9e6f2;
+  padding: 10px 12px;
+  border-radius: var(--input-radius);
+  border: 1px solid var(--input-border);
   outline: none;
-  background: #fff;
+  background: var(--input-bg);
   color: var(--text);
   transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
@@ -105,8 +96,9 @@
 
 .habit-form input[type="text"]:focus,
 .habit-form textarea:focus {
-  border-color: rgba(17, 123, 191, 0.55);
-  box-shadow: 0 0 0 4px rgba(17, 123, 191, 0.12);
+  border-color: var(--input-focus-border);
+  background: #fff;
+  box-shadow: var(--input-focus-shadow);
 }
 
 /* エラー表示 */
@@ -145,48 +137,16 @@
   margin-top: 4px;
 }
 
-/* habyボタン */
-.habit-form-page .haby-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 14px;
-  font-weight: 900;
-  font-size: 13px;
-  text-decoration: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-}
-
-.habit-form-page .haby-btn--primary {
-  color: #fff;
-  background: var(--haby-blue);
-  box-shadow: 0 10px 20px rgba(17, 123, 191, 0.22);
-}
-
-.habit-form-page .haby-btn--ghost {
-  color: var(--text);
-  background: #fff;
-  border-color: #d9e6f2;
-}
-
-.habit-form-page .haby-btn--danger {
-  color: #fff;
-  background: var(--danger);
-  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.18);
-}
 
 /* 補助リンク */
 .habit-form__back {
   font-size: 13px;
-  color: var(--muted);
+  color: var(--text-muted);
   text-decoration: none;
 }
 
 .habit-form__back:hover {
-  color: var(--haby-blue);
+  color: var(--brand);
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
@@ -204,7 +164,7 @@
   border: 1px solid #d9e6f2;
   border-radius: 20px;
   background: #fff;
-  color: var(--muted);
+  color: var(--text-muted);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
@@ -212,8 +172,8 @@
 }
 
 .schedule-preset-btn:hover {
-  border-color: var(--haby-blue);
-  color: var(--haby-blue);
+  border-color: var(--brand);
+  color: var(--brand);
   background: rgba(17, 123, 191, 0.05);
 }
 
@@ -244,21 +204,21 @@
   border-radius: 50%;
   border: 2px solid #d9e6f2;
   background: #fff;
-  color: var(--muted);
+  color: var(--text-muted);
   font-size: 13px;
   font-weight: 700;
   transition: all 0.15s ease;
 }
 
 .schedule-day-toggle:hover .schedule-day-toggle__label {
-  border-color: var(--haby-blue);
-  color: var(--haby-blue);
+  border-color: var(--brand);
+  color: var(--brand);
 }
 
 .schedule-day-toggle.is-selected .schedule-day-toggle__label,
 .schedule-day-toggle input[type="checkbox"]:checked + .schedule-day-toggle__label {
-  border-color: var(--haby-blue);
-  background: var(--haby-blue);
+  border-color: var(--brand);
+  background: var(--brand);
   color: #fff;
   box-shadow: 0 4px 12px rgba(17, 123, 191, 0.25);
 }
@@ -294,7 +254,7 @@
 
   .habit-form-hero {
     padding: 12px 12px 10px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .habit-form-hero__title {
@@ -303,13 +263,7 @@
 
   .habit-form-card {
     padding: 12px;
-    border-radius: 14px;
-  }
-
-  .habit-form input[type="text"],
-  .habit-form textarea {
-    padding: 10px;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
   }
 
   .schedule-days-presets {
@@ -340,12 +294,6 @@
   .habit-form__actions .haby-btn {
     width: 100%;
     justify-content: center;
-  }
-
-  .habit-form-page .haby-btn {
-    padding: 8px 10px;
-    font-size: 12px;
-    border-radius: 12px;
   }
 }
 

--- a/app/assets/stylesheets/pages/habit_show.css
+++ b/app/assets/stylesheets/pages/habit_show.css
@@ -2,22 +2,13 @@
 
 /* 画面全体 */
 .habit-show-page {
-  --haby-blue: #117BBF;
-  --haby-mint: #6AACB0;
-  --text: #0f172a;
-  --muted: #64748b;
-  --line: #e6eef5;
-  --bg: #f6fbff;
-  --card: #ffffff;
-  --danger: #ef4444;
-
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
-  padding: 18px 14px 28px;
-  background: #fff;
+  padding: var(--page-padding);
+  background: var(--bg);
 }
 
 .habit-show-container {
-  max-width: 720px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   display: grid;
   gap: 14px;
@@ -25,11 +16,11 @@
 
 /* ヒーロー */
 .habit-show-hero {
-  background: linear-gradient(135deg, rgba(17,123,191,0.18), rgba(106,172,176,0.14));
-  border: 1px solid rgba(17,123,191,0.18);
-  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(17, 123, 191, 0.18), rgba(106, 172, 176, 0.14));
+  border: 1px solid rgba(17, 123, 191, 0.18);
+  border-radius: var(--card-radius);
   padding: 14px 14px 12px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .habit-show-hero__titleRow {
@@ -41,15 +32,15 @@
 
 .habit-show-hero__title {
   margin: 0;
-  font-size: 18px;
-  font-weight: 950;
+  font-size: var(--page-title-size);
+  font-weight: 800;
   color: var(--text);
 }
 
 .habit-show-hero__subtitle {
   margin: 6px 0 0;
   font-size: 13px;
-  color: var(--muted);
+  color: var(--text-muted);
 }
 
 /* バッジ */
@@ -59,7 +50,7 @@
   border-radius: 999px;
   font-size: 12px;
   font-weight: 900;
-  color: var(--haby-blue);
+  color: var(--brand);
   background: rgba(17,123,191,0.10);
   border: 1px solid rgba(17,123,191,0.18);
 }
@@ -68,11 +59,11 @@
 .habit-show-card {
   position: relative;
   overflow: hidden;
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
   padding: 14px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .habit-show-card::before {
@@ -95,7 +86,7 @@
   margin: 0;
   font-size: 12px;
   font-weight: 900;
-  color: var(--muted);
+  color: var(--text-muted);
   letter-spacing: 0.2px;
 }
 
@@ -111,45 +102,13 @@
 .habit-show-empty {
   text-align: center;
   padding: 22px 14px;
-  border-radius: 18px;
-  border: 1px dashed rgba(17,123,191,0.25);
-  background: rgba(17,123,191,0.06);
-  color: var(--muted);
+  border-radius: var(--card-radius);
+  border: 1px dashed rgba(17, 123, 191, 0.25);
+  background: rgba(17, 123, 191, 0.06);
+  color: var(--text-muted);
   position: relative;
 }
 
-/* ボタン */
-.habit-show-page .haby-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 14px;
-  font-weight: 900;
-  font-size: 13px;
-  text-decoration: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-}
-
-.habit-show-page .haby-btn--primary {
-  color: #fff;
-  background: var(--haby-blue);
-  box-shadow: 0 10px 20px rgba(17,123,191,0.22);
-}
-
-.habit-show-page .haby-btn--ghost {
-  color: var(--text);
-  background: #fff;
-  border-color: #d9e6f2;
-}
-
-.habit-show-page .haby-btn--danger {
-  color: #fff;
-  background: var(--danger);
-  box-shadow: 0 10px 20px rgba(239,68,68,0.18);
-}
 
 .habit-show-actions {
   display: flex;
@@ -165,7 +124,7 @@
 
   .habit-show-hero {
     padding: 12px 12px 10px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .habit-show-hero__titleRow {
@@ -179,7 +138,7 @@
 
   .habit-show-card {
     padding: 12px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .habit-show-card::before {
@@ -192,10 +151,4 @@
     gap: 6px;
   }
 
-  .habit-show-page .haby-btn {
-    padding: 7px 8px;
-    font-size: 11px;
-    border-radius: 12px;
-    gap: 4px;
-  }
 }

--- a/app/assets/stylesheets/pages/habits.css
+++ b/app/assets/stylesheets/pages/habits.css
@@ -2,21 +2,13 @@
 
 /* ページ全体 */
 .habits-page {
-  --haby-blue: #117BBF;
-  --haby-mint: #6AACB0;
-  --text: #0f172a;
-  --muted: #64748b;
-  --line: #e6eef5;
-  --bg: #f6fbff;
-  --card: #ffffff;
-
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
-  padding: 18px 14px 28px;
-  background: #fff;
+  padding: var(--page-padding);
+  background: var(--bg);
 }
 
 .habits-container {
-  max-width: 720px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   display: grid;
   gap: 14px;
@@ -26,18 +18,18 @@
 .habits-hero {
   background: linear-gradient(
     135deg,
-    rgba(17,123,191,0.18),
-    rgba(106,172,176,0.14)
+    rgba(17, 123, 191, 0.18),
+    rgba(106, 172, 176, 0.14)
   );
-  border: 1px solid rgba(17,123,191,0.18);
-  border-radius: 18px;
+  border: 1px solid rgba(17, 123, 191, 0.18);
+  border-radius: var(--card-radius);
   padding: 14px 14px 12px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .habits-hero__title {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--page-title-size);
   font-weight: 800;
   color: var(--text);
   letter-spacing: 0.2px;
@@ -46,16 +38,16 @@
 .habits-hero__subtitle {
   margin: 6px 0 0;
   font-size: 13px;
-  color: var(--muted);
+  color: var(--text-muted);
 }
 
 /* 共通カード */
 .haby-card {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
   padding: 14px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 /* 一覧グリッド */
@@ -68,11 +60,11 @@
 .habit-item {
   position: relative;
   overflow: hidden;
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
   padding: 14px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
   transition:
     transform 0.12s ease,
     box-shadow 0.12s ease,
@@ -81,7 +73,7 @@
 
 .habit-item:hover {
   transform: translateY(-2px);
-  border-color: rgba(17,123,191,0.22);
+  border-color: rgba(17, 123, 191, 0.22);
   box-shadow: 0 14px 35px rgba(15, 23, 42, 0.10);
 }
 
@@ -105,7 +97,7 @@
 }
 
 .habit-item__name a:hover {
-  color: var(--haby-blue);
+  color: var(--brand);
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
@@ -118,9 +110,9 @@
   border-radius: 999px;
   font-size: 12px;
   font-weight: 800;
-  color: var(--haby-blue);
+  color: var(--brand);
   background: rgba(88, 157, 200, 0.10);
-  border: 1px solid rgba(17,123,191,0.18);
+  border: 1px solid rgba(17, 123, 191, 0.18);
 }
 
 .habit-badge-danger {
@@ -141,41 +133,15 @@
   gap: 15px;
 }
 
-/* ボタン */
-.habits-page .haby-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 14px;
-  font-weight: 800;
-  font-size: 13px;
-  text-decoration: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-}
-
-.habits-page .haby-btn--primary {
-  color: #fff;
-  background: var(--haby-blue);
-  box-shadow: 0 10px 20px rgba(17,123,191,0.22);
-}
-
-.habits-page .haby-btn--ghost {
-  color: var(--text);
-  background: #fff;
-  border-color: var(--line);
-}
 
 /* 0件のとき */
 .habits-empty {
   text-align: center;
   padding: 22px 14px;
-  border-radius: 18px;
-  border: 1px dashed rgba(17,123,191,0.25);
-  background: rgba(17,123,191,0.06);
-  color: var(--muted);
+  border-radius: var(--card-radius);
+  border: 1px dashed rgba(17, 123, 191, 0.25);
+  background: rgba(17, 123, 191, 0.06);
+  color: var(--text-muted);
 }
 
 .habits-empty__title {
@@ -206,7 +172,7 @@
 
   .habit-item {
     padding: 12px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .habit-item__head {
@@ -226,11 +192,5 @@
 
   .habit-item__actions {
     gap: 10px;
-  }
-
-  .habits-page .haby-btn {
-    padding: 8px 10px;
-    font-size: 12px;
-    border-radius: 12px;
   }
 }

--- a/app/assets/stylesheets/pages/static_pages.css
+++ b/app/assets/stylesheets/pages/static_pages.css
@@ -1,10 +1,5 @@
 /* 静的ページ（プライバシーポリシー・利用規約・お問い合わせ）共通 */
 .static-page {
-  --haby-blue: #117BBF;
-  --haby-mint: #6AACB0;
-  --text: #1e293b;
-  --muted: #64748b;
-  --line: #e2e8f0;
 
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
   padding: 20px 16px 40px;
@@ -41,14 +36,14 @@
   border-radius: 20px;
   font-size: 12px;
   font-weight: 600;
-  color: var(--haby-blue);
+  color: var(--brand);
   background: #ffffff;
 }
 
 /* コンテンツカード */
 .static-page__content {
   background: #ffffff;
-  border: 1px solid var(--line);
+  border: 1px solid var(--border);
   border-radius: 16px;
   padding: 24px 20px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
@@ -78,13 +73,13 @@
   display: block;
   width: 4px;
   height: 20px;
-  background: var(--haby-blue);
+  background: var(--brand);
   border-radius: 2px;
 }
 
 .static-page__text {
   font-size: 14px;
-  color: var(--muted);
+  color: var(--text-muted);
   line-height: 1.85;
   margin: 0 0 12px;
 }
@@ -103,7 +98,7 @@
 .static-page__list li {
   position: relative;
   font-size: 14px;
-  color: var(--muted);
+  color: var(--text-muted);
   line-height: 1.85;
   padding-left: 22px;
   margin-bottom: 10px;
@@ -120,7 +115,7 @@
   top: 8px;
   width: 6px;
   height: 6px;
-  background: var(--haby-blue);
+  background: var(--brand);
   border-radius: 50%;
 }
 
@@ -131,7 +126,7 @@
 
 /* リンク */
 .static-page__content a {
-  color: var(--haby-blue);
+  color: var(--brand);
   text-decoration: none;
   font-weight: 600;
   transition: color 0.2s ease;
@@ -158,7 +153,7 @@
   flex-shrink: 0;
   width: 28px;
   height: 28px;
-  background: var(--haby-blue);
+  background: var(--brand);
   color: #ffffff;
   border-radius: 50%;
   font-size: 14px;
@@ -201,14 +196,14 @@
 .contact-page__title {
   font-size: 22px;
   font-weight: 700;
-  color: var(--haby-blue);
+  color: var(--brand);
   text-align: center;
   margin: 0 0 8px;
 }
 
 .contact-page__subtitle {
   font-size: 13px;
-  color: var(--muted);
+  color: var(--text-muted);
   text-align: center;
   margin: 0 0 20px;
 }

--- a/app/assets/stylesheets/pages/today.css
+++ b/app/assets/stylesheets/pages/today.css
@@ -1,13 +1,5 @@
 /* Today  */
 
-:root {
-  --haby-primary: #117bbf;
-  --haby-secondary: #6aacb0;
-  --haby-text: #0f172a;
-  --haby-muted: rgba(15, 23, 42, 0.62);
-  --haby-line: rgba(17, 123, 191, 0.18);
-}
-
 .comingsoon {
   position: relative;
   min-height: calc(100vh - 64px);
@@ -46,7 +38,7 @@
   border-radius: 22px;
   background: rgba(255, 255, 255, 0.78);
   backdrop-filter: blur(10px);
-  border: 1px solid var(--haby-line);
+  border: 1px solid var(--card-border);
   box-shadow:
     0 18px 42px rgba(15, 23, 42, 0.08),
     0 6px 18px rgba(17, 123, 191, 0.08);
@@ -66,7 +58,7 @@
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: var(--haby-primary);
+  background: var(--brand);
   box-shadow: 0 0 0 6px rgba(17, 123, 191, 0.16);
   animation: habyPulse 1.6s ease-in-out infinite;
 }
@@ -88,13 +80,13 @@
   font-size: 28px;
   line-height: 1.2;
   letter-spacing: 0.02em;
-  color: var(--haby-text);
+  color: var(--text);
   font-weight: 950;
 }
 
 .comingsoon__lead {
   margin: 0 0 14px;
-  color: var(--haby-muted);
+  color: var(--text-muted);
   font-size: 14px;
   line-height: 1.8;
 }
@@ -209,12 +201,12 @@
 
 .todays-habits-page {
   min-height: calc(100vh - var(--bottom-nav-height, 0px));
-  padding: 18px 14px 28px;
-  background: #fff;
+  padding: var(--page-padding);
+  background: var(--bg);
 }
 
 .todays-habits-container {
-  max-width: 720px;
+  max-width: var(--page-max-width);
   margin: 0 auto;
   display: grid;
   gap: 16px;
@@ -228,29 +220,29 @@
     rgba(106, 172, 176, 0.14)
   );
   border: 1px solid rgba(17, 123, 191, 0.18);
-  border-radius: 18px;
+  border-radius: var(--card-radius);
   padding: 16px;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .todays-habits-hero__title {
   margin: 0;
-  font-size: 20px;
-  font-weight: 900;
-  color: var(--haby-text);
+  font-size: var(--page-title-size);
+  font-weight: 800;
+  color: var(--text);
 }
 
 .todays-habits-hero__date {
   margin: 6px 0 0;
   font-size: 13px;
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 /* Section */
 .todays-habits-section {
   background: #fff;
-  border: 1px solid rgba(17, 123, 191, 0.12);
-  border-radius: 18px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
   padding: 14px;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
 }
@@ -266,21 +258,21 @@
   margin: 0 0 12px;
   font-size: 14px;
   font-weight: 800;
-  color: var(--haby-text);
+  color: var(--text);
 }
 
 .todays-habits-section__icon {
   display: flex;
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 .todays-habits-section__icon--completed {
-  color: var(--haby-primary);
+  color: var(--brand);
 }
 
 .todays-habits-section__count {
   font-weight: 600;
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 /* Habit List */
@@ -298,8 +290,8 @@
   gap: 12px;
   padding: 12px 14px;
   background: #fff;
-  border: 1px solid rgba(17, 123, 191, 0.12);
-  border-radius: 14px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
   transition: box-shadow 0.15s ease, transform 0.15s ease;
   overflow: hidden;
 }
@@ -322,21 +314,21 @@
   margin: 0;
   font-size: 14px;
   font-weight: 700;
-  color: var(--haby-text);
+  color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .todays-habit-item--completed .todays-habit-item__name {
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 .todays-habit-item__schedule {
   display: inline-block;
   margin-top: 4px;
   font-size: 11px;
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 /* Habit Button */
@@ -356,7 +348,7 @@
 }
 
 .todays-habit-btn:not(.todays-habit-btn--completed) {
-  background: var(--haby-primary);
+  background: var(--brand);
   color: #fff;
   box-shadow: 0 4px 12px rgba(17, 123, 191, 0.25);
 }
@@ -373,7 +365,7 @@
 
 .todays-habit-btn--completed {
   background: rgba(17, 123, 191, 0.08);
-  color: var(--haby-primary);
+  color: var(--brand);
   border: 1px solid rgba(17, 123, 191, 0.18);
 }
 
@@ -393,12 +385,12 @@
     rgba(106, 172, 176, 0.06)
   );
   border: 1px solid rgba(17, 123, 191, 0.15);
-  border-radius: 18px;
+  border-radius: var(--card-radius);
   text-align: center;
 }
 
 .todays-habits-complete-message__icon {
-  color: var(--haby-primary);
+  color: var(--brand);
   margin-bottom: 12px;
 }
 
@@ -406,7 +398,7 @@
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: var(--haby-text);
+  color: var(--text);
 }
 
 /* Empty State */
@@ -414,21 +406,21 @@
   text-align: center;
   padding: 32px 16px;
   background: rgba(17, 123, 191, 0.04);
-  border: 1px solid rgba(17, 123, 191, 0.12);
-  border-radius: 18px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
 }
 
 .todays-habits-empty__title {
   margin: 0 0 8px;
   font-size: 16px;
   font-weight: 800;
-  color: var(--haby-text);
+  color: var(--text);
 }
 
 .todays-habits-empty__text {
   margin: 0 0 16px;
   font-size: 13px;
-  color: var(--haby-muted);
+  color: var(--text-muted);
 }
 
 .todays-habits-empty__actions {
@@ -438,31 +430,6 @@
   flex-wrap: wrap;
 }
 
-.todays-habits-empty__actions .haby-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 16px;
-  border-radius: 12px;
-  font-size: 13px;
-  font-weight: 700;
-  text-decoration: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.todays-habits-empty__actions .haby-btn--primary {
-  background: var(--haby-primary);
-  color: #fff;
-  box-shadow: 0 4px 12px rgba(17, 123, 191, 0.25);
-}
-
-.todays-habits-empty__actions .haby-btn--ghost {
-  background: #fff;
-  color: var(--haby-text);
-  border-color: rgba(17, 123, 191, 0.18);
-}
 
 /* ── Responsive: Today's Habits ── */
 @media (max-width: 480px) {
@@ -472,7 +439,7 @@
 
   .todays-habits-hero {
     padding: 12px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .todays-habits-hero__title {
@@ -481,12 +448,12 @@
 
   .todays-habits-section {
     padding: 12px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .todays-habit-item {
     padding: 10px 12px;
-    border-radius: 12px;
+    border-radius: var(--radius-sm);
     gap: 8px;
   }
 
@@ -501,15 +468,10 @@
 
   .todays-habits-complete-message {
     padding: 18px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
   }
 
   .todays-habits-empty {
     padding: 24px 12px;
-  }
-
-  .todays-habits-empty__actions .haby-btn {
-    padding: 8px 12px;
-    font-size: 12px;
   }
 }


### PR DESCRIPTION
## 概要                                    
各ページで個別にハードコードされていたCSS値を共通CSSに統一させ、二重定義されていたCSSを修正し全体のレイアウト・デザインを統一・修正しました。      

## 目的                                                                      
認証画面・アカウント画面・習慣系ページ間で、ボタンなどのCSSにばらつきがあり、画面遷移時にUIの不統一感があったため見やすく改善した。

## 作業内容                                                                  
- variables.cssに追記
- 各ページCSSのローカル変数定義を削除し、共通変数に置き換え                 
- 4箇所に重複定義されていた .haby-btn を共通化し、各ページからは削除
- ボタン角丸を角丸にに統一、heroタイトルの font-weight を800に統一

## 確認事項                                                                  
- ログイン・新規登録画面のレイアウトが崩れていないこと                    
- 習慣一覧・登録・編集・詳細画面のカード表示が統一されていること
- アカウント画面・各設定フォームの表示が統一されていること                
- カレンダー画面の色分け表示が正常に動作すること                          
- モバイル・デスクトップの両方でレスポンシブ表示が崩れないこと                                                                  

## 関連issue                                                                 
- close #104                                                               

## 備考                                                      
- HTMLの変更はなし（CSS変更のみ）       