### PR TITLE
バリデーション強化・修正

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -17,8 +17,7 @@ class HabitsController < ApplicationController
     if @habit.save
       redirect_to habits_path, notice: "習慣を追加しました"
     else
-      prepare_index
-      render :index, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -51,9 +50,5 @@ class HabitsController < ApplicationController
 
   def habit_params
     params.require(:habit).permit(:name, :detail, schedule_days: [])
-  end
-
-  def prepare_index
-    @habits = current_user.habits.order(created_at: :desc)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -129,25 +129,20 @@ class PagesController < ApplicationController
 
   # メールアドレス変更（現在のパスワードを要求）
   def edit_email
+    redirect_to account_path, alert: "Googleアカウントで連携中のため、メールアドレスは変更できません。" if current_user.provider.present?
   end
 
   def update_email
     if current_user.provider.present?
-      # SNSユーザーはパスワード不要で更新
-      if current_user.update(params.require(:user).permit(:email))
-        bypass_sign_in(current_user)
-        redirect_to account_path, notice: "メールアドレスを変更しました。"
-      else
-        render :edit_email, status: :unprocessable_entity
-      end
+      redirect_to account_path, alert: "Googleアカウントで連携中のため、メールアドレスは変更できません。"
+      return
+    end
+
+    if current_user.update_with_password(email_params)
+      bypass_sign_in(current_user)
+      redirect_to account_path, notice: "メールアドレスを変更しました。"
     else
-      # Devise の update_with_password を利用（current_password が必要）
-      if current_user.update_with_password(email_params)
-        bypass_sign_in(current_user)
-        redirect_to account_path, notice: "メールアドレスを変更しました。"
-      else
-        render :edit_email, status: :unprocessable_entity
-      end
+      render :edit_email, status: :unprocessable_entity
     end
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,5 +1,5 @@
 class Contact < ApplicationRecord
-  validates :name, length: { maximum: 100 }, allow_blank: true
+  validates :name, presence: true, length: { maximum: 100 }, no_html_tags: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :message, presence: true, length: { maximum: 5000 }
+  validates :message, presence: true, length: { maximum: 5000 }, no_html_tags: true
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -16,7 +16,9 @@ class Habit < ApplicationRecord
     4 => "木", 5 => "金", 6 => "土"
   }.freeze
 
-  validates :name, presence: true, length: { maximum: 100 }
+  validates :name, presence: true, length: { maximum: 100 }, no_html_tags: true,
+                   uniqueness: { scope: :user_id, message: "は既に登録されています" }
+  validates :detail, length: { maximum: 5000 }, no_html_tags: true
   validates :current_streak, :longest_streak, numericality: { greater_than_or_equal_to: 0 }
 
   scope :active_on, ->(date) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
-  validates :name, presence: true, length: { maximum: 50 }
+  validates :name, presence: true, length: { maximum: 50 }, no_html_tags: true
 
   has_many :habits, dependent: :destroy
   has_many :habit_logs, dependent: :destroy

--- a/app/validators/no_html_tags_validator.rb
+++ b/app/validators/no_html_tags_validator.rb
@@ -1,0 +1,11 @@
+class NoHtmlTagsValidator < ActiveModel::EachValidator
+  HTML_TAG_PATTERN = /<[^>]*>/
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if HTML_TAG_PATTERN.match?(value)
+      record.errors.add(attribute, :no_html_tags, message: "にHTMLタグは使用できません")
+    end
+  end
+end

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -20,7 +20,7 @@
         <% end %>
 
         <div class="contact-form__field">
-          <%= f.label :name, "お名前（任意）", class: "contact-form__label" %>
+          <%= f.label :name, "お名前（必須）", class: "contact-form__label" %>
           <%= f.text_field :name, maxlength: 100, class: "contact-form__input", placeholder: "山田 太郎" %>
         </div>
 

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -18,10 +18,10 @@
     <li class="account-menu__item">
       <%= link_to "名前を変更", edit_account_name_path, class: "account-menu__link" %>
     </li>
-    <li class="account-menu__item">
-      <%= link_to "メールアドレスを変更", edit_account_email_path, class: "account-menu__link" %>
-    </li>
     <% unless current_user.provider.present? %>
+      <li class="account-menu__item">
+        <%= link_to "メールアドレスを変更", edit_account_email_path, class: "account-menu__link" %>
+      </li>
       <li class="account-menu__item">
         <%= link_to "パスワードを変更", edit_account_password_path, class: "account-menu__link" %>
       </li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,11 +2,30 @@ ja:
   activerecord:
     models:
       contact: "お問い合わせ"
+      user: "ユーザー"
+      habit: "習慣"
+      habit_log: "服用ログ"
     attributes:
       contact:
         name: "お名前"
         email: "メールアドレス"
         message: "お問い合わせ内容"
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+        current_password: "現在のパスワード"
+      habit:
+        name: "習慣名"
+        detail: "メモ"
+        current_streak: "現在の連続日数"
+        longest_streak: "最長連続日数"
+        schedule_days: "実施曜日"
+      habit_log:
+        log_date: "記録日"
+        is_taken: "服用状況"
+        logged_at: "記録日時"
   devise:
     passwords:
       no_token: "リセットトークンがありません。パスワードリセットメールのリンクからアクセスしてください。"

--- a/db/migrate/20260417075653_add_unique_index_to_habits_name.rb
+++ b/db/migrate/20260417075653_add_unique_index_to_habits_name.rb
@@ -1,0 +1,28 @@
+class AddUniqueIndexToHabitsName < ActiveRecord::Migration[7.2]
+  def up
+    execute <<-SQL.squish
+      DELETE FROM habit_logs
+      WHERE habit_id IN (
+        SELECT id FROM habits
+        WHERE id NOT IN (
+          SELECT MIN(id) FROM habits GROUP BY user_id, name
+        )
+      )
+    SQL
+
+    execute <<-SQL.squish
+      DELETE FROM habits
+      WHERE id NOT IN (
+        SELECT MIN(id) FROM habits GROUP BY user_id, name
+      )
+    SQL
+
+    remove_index :habits, [ :user_id, :name ]
+    add_index :habits, [ :user_id, :name ], unique: true
+  end
+
+  def down
+    remove_index :habits, [ :user_id, :name ]
+    add_index :habits, [ :user_id, :name ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_12_071457) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_17_075653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_12_071457) do
     t.datetime "updated_at", null: false
     t.integer "schedule_days", default: [], array: true
     t.index ["schedule_days"], name: "index_habits_on_schedule_days", using: :gin
-    t.index ["user_id", "name"], name: "index_habits_on_user_id_and_name"
+    t.index ["user_id", "name"], name: "index_habits_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Contact, type: :model do
     it { is_expected.to validate_length_of(:message).is_at_most(5000) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
 
-    it "名前が空でもバリデーション通過する" do
+    it "名前が空だとバリデーションエラーになる" do
       contact = build(:contact, name: "")
-      expect(contact).to be_valid
+      expect(contact).not_to be_valid
     end
 
     it "正しいメールアドレス形式を受け入れる" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe "Pages", type: :request do
     context "SNSユーザー" do
       before { sign_in sns_user }
 
-      it "パスワードなしでメールアドレスを更新できる" do
+      it "メールアドレスの変更が拒否される" do
         patch account_email_path, params: {
           user: { email: "newsns@example.com" }
         }
         expect(response).to redirect_to(account_path)
-        expect(sns_user.reload.email).to eq("newsns@example.com")
+        expect(sns_user.reload.email).not_to eq("newsns@example.com")
       end
     end
   end


### PR DESCRIPTION
## 概要                                                                           
フォームのバリデーション強化とセキュリティ対策を実施しました。また、フォーム入力値の検証不足やGoogle 
ログインユーザーのメールアドレス変更が可能だった問題を修正しました。                   

## 目的                                                                           
ユーザーが不正な入力や意図しない操作を行えないようにし、アプリケーション全体の 
安全性と信頼性を向上させるため。

## 作業内容
- Googleログインユーザーのメールアドレス変更を制限
- 習慣登録時のバリデーションエラーメッセージが表示されない問題を修正
- エラーメッセージを日本語化
- 習慣の説明文に5000文字制限のバリデーションを追加                   
- HTMLタグを含む入力を拒否するバリデーターを作成し、全テキスト入力項目に適用
- 同一ユーザーによる習慣名の重複登録を禁止
- お問い合わせフォームの名前を必須項目に変更

## 確認事項
- Googleログインユーザーでメールアドレス変更画面にアクセスできないこと         
- 習慣名が空・100文字超・HTMLタグ入り・重複名で登録時にエラーメッセージが表示されること                     
- お問い合わせフォームで名前未入力時にエラーメッセージが表示されること         

## 関連issue                                                                      
- close #133 

## 備考                                                                           
- 