### PR TITLE
本リリースに向けての微細な変更

### DIFF
--- a/app/assets/stylesheets/base/layout.css
+++ b/app/assets/stylesheets/base/layout.css
@@ -11,6 +11,7 @@
 
 html, body {
   overflow-x: hidden;
+  font-family: var(--font-sans);
 }
 
 @supports not (overflow-x: clip) {

--- a/app/assets/stylesheets/base/variables.css
+++ b/app/assets/stylesheets/base/variables.css
@@ -35,8 +35,8 @@
   --space-6: 32px;
 
   /* Typography */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI",
-               "Noto Sans JP", sans-serif;
+  --font-sans: "Noto Sans JP", ui-sans-serif, system-ui, -apple-system,
+               "Segoe UI", sans-serif;
   --font-size-base: 15px;
   --line-height: 1.6;
 

--- a/app/assets/stylesheets/pages/home.css
+++ b/app/assets/stylesheets/pages/home.css
@@ -1175,6 +1175,15 @@
     padding: 28px 48px;
   }
 
+  .slider__slide--photo {
+    padding: 0;
+  }
+
+  .slider__slide--photo .slider__slide-body {
+    justify-content: center;
+    padding: 0 24px;
+  }
+
   .slider__slide-icon {
     font-size: 36px;
     margin-bottom: 10px;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -199,7 +199,7 @@
         <p class="visual-break__text">
           サプリや薬の管理は、意外とむずかしい。<br>
           でも、habyがあれば大丈夫。<br>
-          シンプルな記録と、やさしいリマインドで、<br>
+          シンプルな記録で、<br>
           毎日の健康習慣が自然と身につきます。
         </p>
         <div class="visual-break__chips">
@@ -284,7 +284,7 @@
         <div class="step__card">
           <span class="step__label">STEP 1</span>
           <h3 class="step__title">習慣を登録</h3>
-          <p class="step__text">飲んでいる薬やサプリメントを登録するだけ。名前とメモを入力して、あなただけのリストを作りましょう。</p>
+          <p class="step__text">飲んでいる薬やサプリメント、行いたい行動習慣を登録するだけ。名前とメモを入力して、あなただけのリストを作りましょう。</p>
         </div>
       </div>
 
@@ -296,7 +296,7 @@
         <div class="step__card">
           <span class="step__label">STEP 2</span>
           <h3 class="step__title">毎日ワンタップ</h3>
-          <p class="step__text">飲んだらタップ。たった10秒で記録完了。忙しい朝でも負担になりません。</p>
+          <p class="step__text">習慣を達成したらタップ。たった10秒で記録完了。忙しい朝でも負担になりません。</p>
         </div>
       </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,10 @@
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'favicon_180.png', rel: 'apple-touch-icon', type: 'image/png' %>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap">
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
   </head>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="app-footer__inner">
 
     <!-- 左（コピーライト） -->
-    <p class="app-footer__copy">&copy; 2025 haby</p>
+    <p class="app-footer__copy">&copy; 2026 haby</p>
 
     <!-- 右（リンク群） -->
     <ul class="app-footer__links">


### PR DESCRIPTION
## 概要    
スマホで日本語がゴシック体にならず明朝体になる問題の修正、トップページのスライダー表示調整、その他ホームページ文面の微修正を行いました。                                           

## 目的                                                                        
本リリースに向けて、WEBアプリの内容をよりユーザーにとって見やすい文面とUIにしていくため。                                             

## 作業内容                                                                    
- Google Fonts から Noto Sans JP を読み込み全体に適用 
- 写真スライドのテキストを縦中央に配置。    
- その他トップページの文言の微修正

## 確認事項                                           
- [ ] iPhone 実機 Safari で各ページが明朝体ではなくゴシック体で表示されること
- [ ] スマホ幅（〜480px）でトップページの写真スライドのテキストが写真の縦中央に
配置されていること                                                             
- [ ]トップページ文面・フッターのコピーライト年（2026）表示が意図通りであること     

## 関連issue                                                                   
- close #140 

## 備考
-