### PR TITLE
今日の習慣達成ボタン押下後の件数バグ修正

### DIFF
--- a/app/javascript/controllers/habit_toggle_controller.js
+++ b/app/javascript/controllers/habit_toggle_controller.js
@@ -151,18 +151,18 @@ export default class extends Controller {
     if (!page) return
 
     // アニメーション後に移動
-    setTimeout(() => {
+    setTimeout(async () => {
       if (isNowCompleted) {
-        this.moveToCompletedSection(item)
+        await this.moveToCompletedSection(item)
       } else {
-        this.moveToIncompleteSection(item)
+        await this.moveToIncompleteSection(item)
       }
       this.updateSectionCounts()
       this.updateCompleteMessage()
     }, 300)
   }
 
-  moveToCompletedSection(item) {
+  async moveToCompletedSection(item) {
     let completedSection = document.querySelector(".todays-habits-section--completed")
 
     // 完了セクションがなければ作成
@@ -186,20 +186,20 @@ export default class extends Controller {
     item.style.opacity = "0"
     item.style.transform = "translateX(20px)"
 
-    setTimeout(() => {
-      list.appendChild(item)
-      requestAnimationFrame(() => {
-        item.style.transition = "opacity 0.3s ease, transform 0.3s ease"
-        item.style.opacity = "1"
-        item.style.transform = "translateX(0)"
-      })
-    }, 150)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    list.appendChild(item)
+    requestAnimationFrame(() => {
+      item.style.transition = "opacity 0.3s ease, transform 0.3s ease"
+      item.style.opacity = "1"
+      item.style.transform = "translateX(0)"
+    })
 
     // 未完了セクションが空になったら非表示
     this.hideEmptyIncompleteSection()
   }
 
-  moveToIncompleteSection(item) {
+  async moveToIncompleteSection(item) {
     let incompleteSection = document.querySelector(".todays-habits-section:not(.todays-habits-section--completed)")
 
     // 未完了セクションがなければ作成
@@ -223,14 +223,14 @@ export default class extends Controller {
     item.style.opacity = "0"
     item.style.transform = "translateX(-20px)"
 
-    setTimeout(() => {
-      list.appendChild(item)
-      requestAnimationFrame(() => {
-        item.style.transition = "opacity 0.3s ease, transform 0.3s ease"
-        item.style.opacity = "1"
-        item.style.transform = "translateX(0)"
-      })
-    }, 150)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    list.appendChild(item)
+    requestAnimationFrame(() => {
+      item.style.transition = "opacity 0.3s ease, transform 0.3s ease"
+      item.style.opacity = "1"
+      item.style.transform = "translateX(0)"
+    })
 
     // 完了セクションが空になったら非表示
     this.hideEmptyCompletedSection()


### PR DESCRIPTION
## 概要
今日の習慣ページで、トグル操作後に「未完了 (n件)」「完了済み (n件)」の表示件数が実際の状態と一致しない不具合を修正しました。

## 目的
ユーザーが習慣の完了／未完了を切り替えた際に、画面上の件数表示とセクションの状 
態を正しく同期させ、体験上の違和感を解消するため。

## 作業内容                                                                       
- habit_toggle_controller.js の修正

## 確認事項                                                                       
- /todays_habits で未完了→完了にトグルした際に、未完了／完了済みの件数が正しく更新されること
- すべて完了させた際に未完了セクションが消え、「今日の習慣をすべて達成しました ！」メッセージが表示されること                                                 
- 完了 → 未完了へ戻した際に、達成メッセージが消え未完了セクションが再生成され件数が正しく表示されること                                                       

## 関連issue                                                                      

- 

## 備考
- クライアント側 Stimulusコントローラーのタイミング不整合のみを修正                                    